### PR TITLE
Added Issues Closed / Opened ratio in Issue trends

### DIFF
--- a/api/pages/issue/trends.py
+++ b/api/pages/issue/trends.py
@@ -69,7 +69,6 @@ This is the Issue trends renderer for Kibble
 
 import json
 import time
-import fractions
 
 def run(API, environ, indata, session):
     

--- a/api/pages/issue/trends.py
+++ b/api/pages/issue/trends.py
@@ -69,6 +69,7 @@ This is the Issue trends renderer for Kibble
 
 import json
 import time
+import fractions
 
 def run(API, environ, indata, session):
     
@@ -324,7 +325,8 @@ def run(API, environ, indata, session):
             body = query
         )
     no_closers_before = res['aggregations']['closer']['value']
-    
+    issuesRatioBefore = round(float(no_issues_closed_before) / no_issues_created_before, 2)
+    issuesRatioAfter = str(round(float(no_issues_closed) / no_issues_created, 2))
     
     trends = {
         "created": {
@@ -346,6 +348,11 @@ def run(API, environ, indata, session):
             'before': no_closers_before,
             'after': no_closers,
             'title': "People closing issues this period"
+        },
+        "ratio":{
+            'before': 0,
+            'after': 0,
+            'title': "Issues Closed / Issues Opened Ratio: "+issuesRatioAfter
         }
     }
     


### PR DESCRIPTION
Please consider my contribution to add the metric issues closed / issues opened ratio. The metric is defined by the Chaoss project as an important metric for determining growth maturity and decline. More information on the metric can be found [here](https://github.com/chaoss/metrics/blob/master/activity-metrics/issues-submitted-closed.md). 

![ratio in issue tracker trends](https://user-images.githubusercontent.com/22136995/39541664-08d01cf8-4e0c-11e8-9e0f-fb5c323071ce.png)


Thank you for considering,
Adam 

