### PR TITLE
Improvement css and for rangepicker

### DIFF
--- a/ui/css/kibble.min.css
+++ b/ui/css/kibble.min.css
@@ -3106,3 +3106,7 @@ body.error .logo h1 {
     border-radius: 6px;			
     pointer-events: none;	
 }
+
+.show-calendar {
+    right: auto !important;
+}

--- a/ui/js/coffee/datepicker.coffee
+++ b/ui/js/coffee/datepicker.coffee
@@ -80,7 +80,7 @@ datepicker = (widget) ->
           startDate: if globArgs.from then moment(new Date(globArgs.from*1000)) else moment().subtract(6, 'months'),
           endDate: if globArgs.to then moment(new Date(globArgs.to*1000)) else moment(),
           minDate: '1970-01-01',
-          maxDate: '2020-01-01',
+          maxDate: moment().add(2, 'years').format('YYYY-01-01'),
           dateLimit: {
             days: 365
           },


### PR DESCRIPTION
Hi. We've discussed these changes before.

Firstly, I fixed the bad UI for the date picker. 

This fixes #24

And **maxDate** variable in the **datepicker.coffee** file, have hardcoded value. Because of this, the system will work wrong. I assumed +2 years enough for maxDate.

Now, **maxDate** works like that

```pseudo
var maxDate = CURRENT_YEAR + 2 YEARS
```

Because of I'm not sure that the 1970s could have records, I didn't change minDate value. Actually, there shouldn't be records in the 1970s.

I saw on issue #19