### PR TITLE
Remove css font-family of nav.title to correctly inherit body font-family from bootstrap

### DIFF
--- a/ui/css/kibble.min.css
+++ b/ui/css/kibble.min.css
@@ -19,16 +19,16 @@
     stroke-opacity: .3;
 }
 
-.link_tooltip {	
-    position: absolute;			
-    text-align: center;			
-    min-width: 60px;					
-    min-height: 28px;					
-    padding: 4px;				
-    font: 12px sans-serif;		
-    background: rgba(0,0,0,0.6);	
+.link_tooltip {
+    position: absolute;
+    text-align: center;
+    min-width: 60px;
+    min-height: 28px;
+    padding: 4px;
+    font: 12px sans-serif;
+    background: rgba(0,0,0,0.6);
     color: #FFF;
-    border-radius: 8px;			
+    border-radius: 8px;
     pointer-events: none;
     z-index: 2000;
 }
@@ -121,7 +121,7 @@
 }
 
 .form-control  {
-   
+
     width: 100%;
     height: 34px;
     padding: 6px 12px;
@@ -269,7 +269,7 @@ select {
 
 nav.menu {
    position: absolute;
-   
+
     background: #008FD5;
     float: left;
     width: 160px;
@@ -306,7 +306,7 @@ nav.menu > div.sidemenu > ul > a > li {
     min-width: 48px;
     font-size: 0.75rem;
     font-family: montserrat light, sans-serif;
-    background: rgba(0,0,0,0.15);    
+    background: rgba(0,0,0,0.15);
 }
 
 nav.menu > div.sidemenu > ul > a > li {
@@ -331,7 +331,7 @@ nav.menu > div.sidemenu> ul > a > li > img {
 nav.menu > div.sidemenu {
     width: 160px;
     float: left;
-    
+
 }
 
 .sidetitle {
@@ -365,7 +365,6 @@ nav.titlebar {
     margin: 0px;
     padding: 0px;
     height: 46px;
-    font-family: Montserrat, sanf-serif;
     font-size: 32px;
     color: #223;
 }
@@ -459,7 +458,7 @@ div.wrap3 {
     color: #FFF;
     border-radius: 3px;
     padding: 2px 2px 2px 8px;
-    
+
 }
 
 h2 {
@@ -500,7 +499,7 @@ h2 {
     border-radius: 3px;
     height: calc(100% - 42px);
     overflow: visible;
-    
+
 }
 
 .chartChart {
@@ -648,7 +647,7 @@ h2 {
         -webkit-transition: all .3s ease-in-out;
         -o-transition: all .3s ease-in-out;
         transition: all .3s ease-in-out;
-        
+
         text-overflow: ellipsis;
         white-space: nowrap
     }
@@ -3081,7 +3080,7 @@ body.error .logo h1 {
 }
 
 .phonebook_entry > a > img {
-   margin: 2px; 
+   margin: 2px;
 }
 
 .phonebook_entry > div {
@@ -3091,9 +3090,9 @@ body.error .logo h1 {
 }
 
 .punchcard_tooltip {
-    position: absolute;			
-    text-align: center;			
-    min-width: 60px;					
+    position: absolute;
+    text-align: center;
+    min-width: 60px;
     min-height: 24px;
     margin: 8px;
     margin-top: -10px;
@@ -3101,8 +3100,8 @@ body.error .logo h1 {
     border: 1.25px solid #3338;
     line-height: 28px;
     z-index: 1001;
-    font: 12px sans-serif;		
-    background: lightgoldenrodyellow;	
-    border-radius: 6px;			
-    pointer-events: none;	
+    font: 12px sans-serif;
+    background: lightgoldenrodyellow;
+    border-radius: 6px;
+    pointer-events: none;
 }


### PR DESCRIPTION
## Problem
The font of title bars do not match with other contents.

## Solution
I simply removed font-family of nav.title in kibble.min.css to inherit the font-family of body.dashboard from bootstrap.min.css.

## Before & After Screenshots
**Before**: ![image](https://user-images.githubusercontent.com/32972219/59215598-53726e00-8b55-11e9-9e50-f293a3f56dc2.png)
**After**: ![image](https://user-images.githubusercontent.com/32972219/59215781-d1367980-8b55-11e9-9db6-b7b863727d45.png)

## Other Changes
Atom editor automatically removed the white spaces in kibble.min.css.

Please advise on my first pull request. Thank you.