### PR TITLE
Move .gitignore to main directory and ignore .idea

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -136,3 +136,6 @@ dmypy.json
 
 # Cython debug symbols
 cython_debug/
+
+# JetBrains IDE
+/.idea


### PR DESCRIPTION
This commit moves .gitignore file from /docs to main directory as
this is the right place for it to avoid commiting any unwanted
content. Additionaly it add the .idea directory to known ignores
as this is directory used by JetBrains IDEs.