### PR TITLE
Add .github, config yaml and issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -11,13 +11,13 @@ assignees: ''
 Hi! Thanks for submitting issue.
 We are happy that you are using Kibble.
 Please follow below steps when submitting the issue.
+Check our other issues -- maybe similar issue is already reported.
 
-Delete comment block before submitting.
+Please, delete comment block before submitting.
 
 Thank you and have a nice day!
 Kibble team
 -->
-
 
 **Description:**
 <!--
@@ -27,8 +27,8 @@ Could you tell us how it should work in your opinion?
 -->
 
 **Reproduction steps:**
-<!--Provide steps that allow us to reproduce the issue.-->
 <!--
+Provide steps that allow us to reproduce the issue.
 1.
 2.
 3.
@@ -43,4 +43,6 @@ Could you tell us how it should work in your opinion?
 <!--Attach logs if you have.-->
 
 **Other:**
-<!--Provide, attach, describe any other information you think are helpful.-->
+<!--
+Provide, attach, describe any other information you think are helpful.
+-->

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -20,7 +20,11 @@ Kibble team
 
 
 **Description:**
-<!--Please provide detailed description of the issue you want to submit.-->
+<!--
+Please provide a detailed description of the issue you want to submit.
+Please tell us how many times the issue occurred.
+Could you tell us how it should work in your opinion?
+-->
 
 **Reproduction steps:**
 <!--Provide steps that allow us to reproduce the issue.-->
@@ -31,12 +35,6 @@ Kibble team
 -->
 **Actual result:**
 <!--Describe actual system behavior.-->
-
-**Excpected result:**
-<!--Information how it should work or how it should work in your opinion.-->
-
-**Reproduction rate:**
-<!--How many times issue occurred.-->
 
 **OS:**
 <!--Tell us what OS you are using.-->

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,48 @@
+---
+name: Bug report
+about: Problems or issues with Kibble projects
+title: ''
+labels: 'kind:bug'
+assignees: ''
+
+---
+
+<!--
+Hi! Thanks for submitting issue.
+We are happy that you are using Kibble.
+Please follow below steps when submitting the issue.
+
+Delete comment block before submitting.
+
+Thank you and have a nice day!
+Kibble team
+-->
+
+
+**Description:**
+<!--Please provide detailed description of the issue you want to submit.-->
+
+**Reproduction steps:**
+<!--Provide steps that allow us to reproduce the issue.-->
+<!--
+1.
+2.
+3.
+-->
+**Actual result:**
+<!--Describe actual system behavior.-->
+
+**Excpected result:**
+<!--Information how it should work or how it should work in your opinion.-->
+
+**Reproduction rate:**
+<!--How many times issue occurred.-->
+
+**OS:**
+<!--Tell us what OS you are using.-->
+
+**Logs:**
+<!--Attach logs if you have.-->
+
+**Other:**
+<!--Provide, attach, describe any other information you think are helpful.-->

--- a/.github/ISSUE_TEMPLATE/config.ymal
+++ b/.github/ISSUE_TEMPLATE/config.ymal
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,33 @@
+---
+name: Feature request
+about: Idea or feature request  
+title: ''
+labels: 'kind:feature'
+assignees: ''
+
+---
+
+<!--
+Hi! We are happy that you are using Kibble.
+Please follow below steps when submitting the issue.
+Check our other issues -- maybe similar feature is already reported.
+
+Please, delete comment block before submitting.
+
+Thank you and have a nice day!
+Kibble team
+-->
+
+**Description**
+<!-- Provide description of your idea/feature. -->
+
+**Use case**
+<!--
+What do you want to achieve with this idea?
+Please tell us about your idea as much as possible.
+Focus on the user perspective rather than implementation.
+What problem do you want to solve with your idea.
+-->
+
+**Related Issues**
+<!-- Is there any issue related to your idea? -->


### PR DESCRIPTION
Hi folks.
I thought that will be a good idea to make issue template in Kibble. 
Template allows us to understand issue better. We will have more valuable information, logs and steps to reproduce.
IMHO such pieces of information are very important to fix issues faster.

What do you think? 

PR contains:
- issue template
- config.yaml (`blank_issues_enabled: false` prevents to open empty issue)
