### PR TITLE
Make api a package

### DIFF
--- a/api/__init__.py
+++ b/api/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/api/pages/__init__.py
+++ b/api/pages/__init__.py
@@ -26,7 +26,7 @@ import importlib
 import os
 # Define all the submodules we have
 
-rootpath = os.path.dirname(__file__)
+rootpath = os.path.join(os.path.dirname(os.path.realpath(__file__)))
 print("Reading pages from %s" % rootpath)
 
 # Import each submodule into a hash called 'handlers'
@@ -42,6 +42,5 @@ def loadPage(path):
                 p = filepath.replace(rootpath, "")[1:].replace('/', '.')[:-3]
                 xp = p.replace('.', '/')
                 print("Loading endpoint pages.%s as %s" % (p, xp))
-                handlers[xp] = importlib.import_module("pages.%s" % p)
-
+                handlers[xp] = importlib.import_module("api.pages.%s" % p)
 loadPage(rootpath)

--- a/api/plugins/database.py
+++ b/api/plugins/database.py
@@ -20,17 +20,13 @@ This is the ES library for Apache Kibble.
 It stores the elasticsearch handler and config options.
 """
 
-
-# Main imports
-import cgi
-import re
-#import aaa
 import elasticsearch
+
 
 class KibbleESWrapper(object):
     """
-       Class for rewriting old-style queries to the new ones,
-       where doc_type is an integral part of the DB name
+    Class for rewriting old-style queries to the new ones,
+    where doc_type is an integral part of the DB name
     """
     def __init__(self, ES):
         self.ES = ES
@@ -64,6 +60,7 @@ class KibbleESWrapper(object):
             doc_type = '_doc',
             body = body
             )
+
 
 class KibbleESWrapperSeven(object):
     """

--- a/api/plugins/openapi.py
+++ b/api/plugins/openapi.py
@@ -27,9 +27,11 @@ import functools
 import operator
 import re
 
+
 class OpenAPIException(Exception):
     def __init__(self, message):
         self.message = message
+
 
 # Python type names to JSON type names
 py2JSON = {

--- a/api/plugins/session.py
+++ b/api/plugins/session.py
@@ -20,16 +20,11 @@ This is the session library for Apache Kibble.
 It handles setting/getting cookies and user prefs
 """
 
-
-# Main imports
-import cgi
 import re
-import sys
-import traceback
 import http.cookies
 import uuid
-import elasticsearch
 import time
+
 
 class KibbleSession(object):
 

--- a/docker-compose-dev.yaml
+++ b/docker-compose-dev.yaml
@@ -16,7 +16,7 @@ services:
   # Apache Kibble API server
   kibble:
     image: *img
-    command: bash -c "cd api && gunicorn --reload -w 1 -b 0.0.0.0:8001 handler:application"
+    command: bash -c "gunicorn --reload -w 1 -b 0.0.0.0:8001 api.handler:application"
     expose:
       - 8001
     ports:


### PR DESCRIPTION
~This PR depends on #50. Please review only the last commit.~

This PR refactors the `api/` directory to be a proper python package. One of the advantages is that the server can be started from the main directory. 

Closes #49 