### PR TITLE
Use single gitignore and ignore kibble.yaml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Apache Kibble files
+api/yaml/kibble.yaml
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/api/.gitignore
+++ b/api/.gitignore
@@ -1,2 +1,0 @@
-__pycache__
-venv


### PR DESCRIPTION
Content of `api/.gitignore` is already ignored in the main `.gitignore`. Additionally I added the `kibble.yaml` as it seems that it should not be committed. 