### PR TITLE
Add kibana dashboard to dokcer-compose

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -9,7 +9,7 @@ area:docs:
   - '*.md'
 
 area:dev:
-  - '.github/'
+  - '.github/*'
   - '.pre-commit.config.yaml'
   - 'asf.yaml'
   - 'Dockerfile*'

--- a/docker-compose-dev.yaml
+++ b/docker-compose-dev.yaml
@@ -41,8 +41,8 @@ services:
   elasticsearch:
     image: elasticsearch:7.9.2
     ports:
-      - "9200:9200"
-      - "9300:9300"
+      - 9200:9200
+      - 9300:9300
     environment:
       node.name: es01
       discovery.seed_hosts: es02
@@ -56,6 +56,14 @@ services:
       memlock:
         soft: -1
         hard: -1
+
+  # Kibana to view and manage Elasticsearch
+  kibana:
+    image: kibana:7.9.3
+    ports:
+      - 5601:5601
+    depends_on:
+      - elasticsearch
 
 volumes:
   # named volumes can be managed easier using docker-compose


### PR DESCRIPTION
Kibana is a dashboard to manage and visualise data in Elasticsearch:
https://www.elastic.co/kibana

This is purely for development purposes