### PR TITLE
Add scanners to main repository

### DIFF
--- a/kibble/scanners/README.md
+++ b/kibble/scanners/README.md
@@ -1,0 +1,80 @@
+# Kibble Scanner Application
+The Kibble Scanners collect information for the Kibble Suite.
+
+## Setup instructions:
+
+ - Edit conf/config.yaml to match your Kibble service
+
+## How to run:
+
+ - On a daily/weekly/whatever basis, run: `python3 src/kibble-scanner.py`.
+
+### Command line options:
+
+    usage: kibble-scanner.py [-h] [-o ORG] [-f CONFIG] [-a AGE] [-s SOURCE]
+                             [-n NODES] [-t TYPE] [-e EXCLUDE [EXCLUDE ...]]
+                             [-v VIEW]
+
+    optional arguments:
+      -h, --help            show this help message and exit
+      -o ORG, --org ORG     The organisation to gather stats for. If left out, all
+                            organisations will be scanned.
+      -f CONFIG, --config CONFIG
+                            Location of the yaml config file (full path)
+      -a AGE, --age AGE     Minimum age in hours before performing a new scan on
+                            an already processed source. --age 12 will not process
+                            any source that was processed less than 12 hours ago,
+                            but will process new sources.
+      -s SOURCE, --source SOURCE
+                            A specific source (wildcard) to run scans on.
+      -n NODES, --nodes NODES
+                            Number of nodes in the cluster (used for load
+                            balancing)
+      -t TYPE, --type TYPE  Specific type of scanner to run (default is run all
+                            scanners)
+      -e EXCLUDE [EXCLUDE ...], --exclude EXCLUDE [EXCLUDE ...]
+                            Specific type of scanner(s) to exclude
+      -v VIEW, --view VIEW  Specific source view to scan (default is scan all
+                            sources)
+
+
+## Directory structure:
+
+ - `conf/`: Config files
+ - `src/`:
+ - - `kibble-scanner.py`: Main script for launching scans
+ - - `plugins/`:
+ - - - `brokers`: The various database brokers (ES or JSON API)
+ - - - `utils`: Utility libraries
+ - - - `scanners`: The individual scanner applications
+
+## Currently available scanner plugins:
+
+ - Apache Pony Mail (`plugins/scanners/ponymail.py`)
+ - Atlassian JIRA (`plugins/scanners/jira.py`)
+ - BugZilla Issue Tracker (`plugins/scanners/bugzilla.py`)
+ - BuildBot (`plugins/scanners/buildbot.py`)
+ - Discourse (`plugins/scanners/discourse.py`)
+ - Gerrit Code Review (`plugins/scanners/gerrit.py`)
+ - Git Repository Fetcher (`plugins/scanners/git-sync.py`)
+ - Git Census Counter (`plugins/scanners/git-census.py`)
+ - Git Code Evolution Counter (`plugins/scanners/git-evolution.py`)
+ - Git SLoC Counter (`plugins/scanners/git-sloc.py`)
+ - GitHub Issues/PRs (`plugins/scanners/github.py`)
+ - GitHub Traffic Statistics (`plugins/scanners/github-stats.py`)
+ - GNU Mailman Pipermail (`plugins/scanners/pipermail.py`)
+ - Jenkins (`plugins/scanners/jenkins.py`)
+ - Travis CI (`plugins/scanners/travis.py`)
+
+## Requirements:
+
+ - [cloc](https://github.com/AlDanial/cloc) version 1.76 or later `(optional)`
+ - git binaries
+ - python3 (3.3 or later)
+ - python3-elasticsearch
+ - python3-certifi
+ - python3-yaml
+
+
+# Get involved
+  TBD. Please see https://kibble.apache.org/ for details!

--- a/kibble/scanners/__init__.py
+++ b/kibble/scanners/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/kibble/scanners/brokers/__init__.py
+++ b/kibble/scanners/brokers/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/kibble/scanners/brokers/kibbleES.py
+++ b/kibble/scanners/brokers/kibbleES.py
@@ -1,0 +1,367 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import elasticsearch
+import elasticsearch.helpers
+import sys
+
+KIBBLE_DB_VERSION = 2  # Current DB struct version
+ACCEPTED_DB_VERSIONS = [1, 2]  # Versions we know how to work with.
+
+
+class KibbleESWrapper:
+    """
+    Class for rewriting old-style queries to the new ones,
+    where doc_type is an integral part of the DB name
+    """
+
+    def __init__(self, ES):
+        self.ES = ES
+        self.indices = self.indicesClass(ES)
+
+    def get(self, index, doc_type, id):
+        return self.ES.get(index=index + "_" + doc_type, doc_type="_doc", id=id)
+
+    def exists(self, index, doc_type, id):
+        return self.ES.exists(index=index + "_" + doc_type, doc_type="_doc", id=id)
+
+    def delete(self, index, doc_type, id):
+        return self.ES.delete(index=index + "_" + doc_type, doc_type="_doc", id=id)
+
+    def index(self, index, doc_type, id, body):
+        return self.ES.index(
+            index=index + "_" + doc_type, doc_type="_doc", id=id, body=body
+        )
+
+    def update(self, index, doc_type, id, body):
+        return self.ES.update(
+            index=index + "_" + doc_type, doc_type="_doc", id=id, body=body
+        )
+
+    def search(self, index, doc_type, size=100, body=None):
+        return self.ES.search(
+            index=index + "_" + doc_type, doc_type="_doc", size=size, body=body
+        )
+
+    def count(self, index, doc_type, body=None):
+        return self.ES.count(index=index + "_" + doc_type, doc_type="_doc", body=body)
+
+    class indicesClass:
+        """ Indices helper class """
+
+        def __init__(self, ES):
+            self.ES = ES
+
+        def exists(self, index):
+            return self.ES.indices.exists(index=index)
+
+
+class KibbleESWrapperSeven:
+    """
+       Class for rewriting old-style queries to the new ones,
+       where doc_type is an integral part of the DB name and NOT USED (>= 7.x)
+    """
+
+    def __init__(self, ES):
+        self.ES = ES
+        self.indices = self.indicesClass(ES)
+
+    def get(self, index, doc_type, id):
+        return self.ES.get(index=index + "_" + doc_type, id=id)
+
+    def exists(self, index, doc_type, id):
+        return self.ES.exists(index=index + "_" + doc_type, id=id)
+
+    def delete(self, index, doc_type, id):
+        return self.ES.delete(index=index + "_" + doc_type, id=id)
+
+    def index(self, index, doc_type, id, body):
+        return self.ES.index(index=index + "_" + doc_type, id=id, body=body)
+
+    def update(self, index, doc_type, id, body):
+        return self.ES.update(index=index + "_" + doc_type, id=id, body=body)
+
+    def search(self, index, doc_type, size=100, body=None):
+        return self.ES.search(index=index + "_" + doc_type, size=size, body=body)
+
+    def count(self, index, doc_type, body=None):
+        return self.ES.count(index=index + "_" + doc_type, body=body)
+
+    class indicesClass:
+        """ Indices helper class """
+
+        def __init__(self, ES):
+            self.ES = ES
+
+        def exists(self, index):
+            return self.ES.indices.exists(index=index)
+
+
+# This is redundant, refactor later?
+def pprint(string, err=False):
+    line = "[core]: %s" % (string)
+    if err:
+        sys.stderr.write(line + "\n")
+    else:
+        print(line)
+
+
+class KibbleBit:
+    """ KibbleBit class with direct ElasticSearch access """
+
+    def __init__(self, broker, organisation, tid):
+        self.config = broker.config
+        self.organisation = organisation
+        self.broker = broker
+        self.json_queue = []
+        self.queueMax = 1000  # Entries to keep before bulk pushing
+        self.pluginname = ""
+        self.tid = tid
+        self.dbname = self.broker.config["elasticsearch"]["database"]
+
+    def __del__(self):
+        """ On unload/delete, push the last chunks of data to ES """
+        if self.json_queue:
+            print("Pushing stragglers")
+            self.bulk()
+
+    def pprint(self, string, err=False):
+        line = "[thread#%i:%s]: %s" % (self.tid, self.pluginname, string)
+        if err:
+            sys.stderr.write(line + "\n")
+        else:
+            print(line)
+
+    def updateSource(self, source):
+        """ Updates a source document, usually with a status update """
+        self.broker.DB.index(
+            index=self.broker.config["elasticsearch"]["database"],
+            doc_type="source",
+            id=source["sourceID"],
+            body=source,
+        )
+
+    def get(self, doctype, docid):
+        """ Fetches a document from the DB """
+        doc = self.broker.DB.get(
+            index=self.broker.config["elasticsearch"]["database"],
+            doc_type=doctype,
+            id=docid,
+        )
+        if doc:
+            return doc["_source"]
+        return None
+
+    def exists(self, doctype, docid):
+        """ Checks whether a document already exists or not """
+        return self.broker.DB.exists(
+            index=self.broker.config["elasticsearch"]["database"],
+            doc_type=doctype,
+            id=docid,
+        )
+
+    def index(self, doctype, docid, document):
+        """ Adds a new document to the index """
+        dbname = self.broker.config["elasticsearch"]["database"]
+        self.broker.DB.index(index=dbname, doc_type=doctype, id=docid, body=document)
+
+    def append(self, t, doc):
+        """ Append a document to the bulk push queue """
+        if not "id" in doc:
+            sys.stderr.write("No doc ID specified!\n")
+            return
+        doc["doctype"] = t
+        self.json_queue.append(doc)
+        # If we've crossed the bulk limit, do a push
+        if len(self.json_queue) > self.queueMax:
+            pprint("Bulk push forced")
+            self.bulk()
+
+    def bulk(self):
+        """ Push pending JSON objects in the queue to ES"""
+        xjson = self.json_queue
+        js_arr = []
+        self.json_queue = []
+        for entry in xjson:
+            js = entry
+            doc = js
+            js["@version"] = 1
+            dbname = self.broker.config["elasticsearch"]["database"]
+            if self.broker.noTypes:
+                dbname += "_%s" % js["doctype"]
+                js_arr.append(
+                    {
+                        "_op_type": "update" if js.get("upsert") else "index",
+                        "_index": dbname,
+                        "_type": "_doc",
+                        "_id": js["id"],
+                        "doc" if js.get("upsert") else "_source": doc,
+                        "doc_as_upsert": True,
+                    }
+                )
+            else:
+                js_arr.append(
+                    {
+                        "_op_type": "update" if js.get("upsert") else "index",
+                        "_index": dbname,
+                        "_type": js["doctype"],
+                        "_id": js["id"],
+                        "doc" if js.get("upsert") else "_source": doc,
+                        "doc_as_upsert": True,
+                    }
+                )
+        try:
+            elasticsearch.helpers.bulk(self.broker.oDB, js_arr)
+        except Exception as err:
+            pprint("Warning: Could not bulk insert: %s" % err)
+
+
+class KibbleOrganisation:
+    """ KibbleOrg with direct ElasticSearch access """
+
+    def __init__(self, broker, org):
+        """ Init an org, set up ElasticSearch for KibbleBits later on """
+
+        self.broker = broker
+        self.id = org
+
+    def sources(self, sourceType=None, view=None):
+        """ Get all sources or sources of a specific type for an org """
+        s = []
+        # Search for all sources of this organisation
+        mustArray = [{"term": {"organisation": self.id}}]
+        if view:
+            res = self.broker.DB.get(
+                index=self.broker.config["elasticsearch"]["database"],
+                doc_type="view",
+                id=view,
+            )
+            if res:
+                mustArray.append({"terms": {"sourceID": res["_source"]["sourceList"]}})
+        # If we want a specific source type, amend the search criteria
+        if sourceType:
+            mustArray.append({"term": {"type": sourceType}})
+        # Run the search, fetch all results, 9999 max. TODO: Scroll???
+        res = self.broker.DB.search(
+            index=self.broker.config["elasticsearch"]["database"],
+            doc_type="source",
+            size=9999,
+            body={"query": {"bool": {"must": mustArray}}, "sort": {"sourceURL": "asc"}},
+        )
+
+        for hit in res["hits"]["hits"]:
+            if sourceType == None or hit["_source"]["type"] == sourceType:
+                s.append(hit["_source"])
+        return s
+
+
+""" Master Kibble Broker Class for direct ElasticSearch access """
+
+
+class Broker:
+    def __init__(self, config):
+        es_config = config["elasticsearch"]
+        auth = None
+        if "user" in es_config:
+            auth = (es_config["user"], es_config["password"])
+        pprint(
+            "Connecting to ElasticSearch database at %s:%i..."
+            % (es_config["hostname"], es_config.get("port", 9200))
+        )
+        es = elasticsearch.Elasticsearch(
+            [
+                {
+                    "host": es_config["hostname"],
+                    "port": int(es_config.get("port", 9200)),
+                    "use_ssl": es_config.get("ssl", False),
+                    "verify_certs": False,
+                    "url_prefix": es_config.get("uri", ""),
+                    "http_auth": auth,
+                }
+            ],
+            max_retries=5,
+            retry_on_timeout=True,
+        )
+        es_info = es.info()
+        pprint("Connected!")
+        self.DB = es
+        self.oDB = es  # Original ES class, always. the .DB may change
+        self.config = config
+        self.bitClass = KibbleBit
+        # This bit is required since ES 6.x and above don't like document types
+        self.noTypes = (
+            True if int(es_info["version"]["number"].split(".")[0]) >= 6 else False
+        )
+        self.seven = (
+            True if int(es_info["version"]["number"].split(".")[0]) >= 7 else False
+        )
+        if self.noTypes:
+            pprint("This is a type-less DB, expanding database names instead.")
+            if self.seven:
+                pprint("We're using ES >= 7.x, NO DOC_TYPE!")
+                es = KibbleESWrapperSeven(es)
+            else:
+                es = KibbleESWrapper(es)
+            self.DB = es
+            if not es.indices.exists(index=es_config["database"] + "_api"):
+                sys.stderr.write(
+                    "Could not find database group %s_* in ElasticSearch!\n"
+                    % es_config["database"]
+                )
+                sys.exit(-1)
+        else:
+            pprint("This DB supports types, utilizing..")
+            if not es.indices.exists(index=es_config["database"]):
+                sys.stderr.write(
+                    "Could not find database %s in ElasticSearch!\n"
+                    % es_config["database"]
+                )
+                sys.exit(-1)
+        apidoc = es.get(index=es_config["database"], doc_type="api", id="current")[
+            "_source"
+        ]
+        # We currently accept and know how to use DB versions 1 and 2.
+        if apidoc["dbversion"] not in ACCEPTED_DB_VERSIONS:
+            if apidoc["dbversion"] > KIBBLE_DB_VERSION:
+                sys.stderr.write(
+                    "The database '%s' uses a newer structure format (version %u) than the scanners (version %u). Please upgrade your scanners.\n"
+                    % (es_config["database"], apidoc["dbversion"], KIBBLE_DB_VERSION)
+                )
+                sys.exit(-1)
+            if apidoc["dbversion"] < KIBBLE_DB_VERSION:
+                sys.stderr.write(
+                    "The database '%s' uses an older structure format (version %u) than the scanners (version %u). Please upgrade your main Kibble server.\n"
+                    % (es_config["database"], apidoc["dbversion"], KIBBLE_DB_VERSION)
+                )
+                sys.exit(-1)
+
+    def organisations(self):
+        """ Return a list of all organisations """
+        orgs = []
+
+        # Run the search, fetch all orgs, 9999 max. TODO: Scroll???
+        res = self.DB.search(
+            index=self.config["elasticsearch"]["database"],
+            doc_type="organisation",
+            size=9999,
+            body={"query": {"match_all": {}}},
+        )
+
+        for hit in res["hits"]["hits"]:
+            org = hit["_source"]["id"]
+            orgClass = KibbleOrganisation(self, org)
+            yield orgClass

--- a/kibble/scanners/config.yaml
+++ b/kibble/scanners/config.yaml
@@ -1,0 +1,39 @@
+# If enabled, kibble scanners will use direct ES connection.
+elasticsearch:
+    enabled:    true
+    hostname:   localhost
+    port:       9200
+    ssl:        false
+    uri:        ""
+    database:   kibble
+
+# If enabled, kibble scanners will use the HTTP JSON API
+broker:
+    enabled:    false
+    url:        https://localhost/api/
+    auth:
+        username:   kibble
+        password:   kibble4life
+
+# Scanner client options
+scanner:
+    # scratchdir: Location for storing file objects like git repos etc
+    # This should be permanent to speed up scans of large repositories
+    # on consecutive scans, but may be ephemeral like /tmp
+    scratchdir:     /tmp
+    # If you are load balancing the scans, you should specify
+    # how many nodes are working, and which one you are,
+    # using the format: $nodeNo/$totalNodes. If there are 4 nodes,
+    # each node will gat 1/4th of all jobs to work on.
+    #balance:        1/4
+
+# Watson/BlueMix configuration for sentiment analysis, if applicable
+#watson:
+#    username:       uuid-here
+#    password:       pass-here
+#    api:            https://gateway-location.watsonplatform.net/tone-analyzer/api
+
+# Azure Text Analysis API configuration, if applicable
+#azure:
+#    apikey: key-here
+#    location: west-us

--- a/kibble/scanners/kibble-scanner.py
+++ b/kibble/scanners/kibble-scanner.py
@@ -1,0 +1,197 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import os
+import threading
+import multiprocessing
+from pprint import pprint
+
+import yaml
+import time
+import argparse
+from kibble.scanners import scanners
+from kibble.scanners.brokers import kibbleES
+
+VERSION = "0.1.0"
+CONFIG_FILE = os.path.join(os.path.dirname(os.path.realpath(__file__)), "config.yaml")
+PENDING_OBJECTS = []
+BIG_LOCK = threading.Lock()
+
+
+def base_parser():
+    arg_parser = argparse.ArgumentParser()
+    arg_parser.add_argument(
+        "-o",
+        "--org",
+        help="The organisation to gather stats for. If left out, all organisations will be scanned.",
+    )
+    arg_parser.add_argument(
+        "-f", "--config", help="Location of the yaml config file (full path)"
+    )
+    arg_parser.add_argument(
+        "-a",
+        "--age",
+        help="Minimum age in hours before performing a new scan on an already processed source. --age 12 will not process any source that was processed less than 12 hours ago, but will process new sources.",
+    )
+    arg_parser.add_argument(
+        "-s", "--source", help="A specific source (wildcard) to run scans on."
+    )
+    arg_parser.add_argument(
+        "-n", "--nodes", help="Number of nodes in the cluster (used for load balancing)"
+    )
+    arg_parser.add_argument(
+        "-t",
+        "--type",
+        help="Specific type of scanner to run (default is run all scanners)",
+    )
+    arg_parser.add_argument(
+        "-e", "--exclude", nargs="+", help="Specific type of scanner(s) to exclude"
+    )
+    arg_parser.add_argument(
+        "-v",
+        "--view",
+        help="Specific source view to scan (default is scan all sources)",
+    )
+    return arg_parser
+
+
+def isMine(ID, config):
+    if config["scanner"].get("balance", None):
+        a = config["scanner"]["balance"].split("/")
+        nodeNo = int(a[0])
+        numNodes = int(a[1])
+        if numNodes == 0:
+            return True
+        bignum = int(ID, 16) % numNodes
+        if bignum == int(nodeNo) - 1:
+            return True
+        return False
+    return True
+
+
+class scanThread(threading.Thread):
+    """ A thread object that grabs an item from the queue and processes
+        it, using whatever plugins will come out to play. """
+
+    def __init__(self, broker, org, i, t=None, e=None):
+        super(scanThread, self).__init__()
+        self.broker = broker
+        self.org = org
+        self.id = i
+        self.bit = self.broker.bitClass(self.broker, self.org, i)
+        self.stype = t
+        self.exclude = e
+        pprint("Initialized thread %i" % i)
+
+    def run(self):
+        global BIG_LOCK, PENDING_OBJECTS
+        time.sleep(0.5)  # Primarily to align printouts.
+        # While there are objects to snag
+        a = 0
+        while PENDING_OBJECTS:
+            BIG_LOCK.acquire(blocking=True)
+            try:
+                # Try grabbing an object (might not be any left!)
+                obj = PENDING_OBJECTS.pop(0)
+            except:
+                pass
+            BIG_LOCK.release()
+            if obj:
+                # If load balancing jobs, make sure this one is ours
+                if isMine(obj["sourceID"], self.broker.config):
+                    # Run through list of scanners in order, apply when useful
+                    for sid, scanner in scanners.enumerate():
+
+                        if scanner.accepts(obj):
+                            self.bit.pluginname = "plugins/scanners/" + sid
+                            # Excluded scanner type?
+                            if self.exclude and sid in self.exclude:
+                                continue
+                            # Specific scanner type or no types mentioned?
+                            if not self.stype or self.stype == sid:
+                                scanner.scan(self.bit, obj)
+            else:
+                break
+        self.bit.pluginname = "core"
+        self.bit.pprint("No more objects, exiting!")
+
+
+def main():
+    pprint("Kibble Scanner v/%s starting" % VERSION)
+    global CONFIG_FILE, PENDING_OBJECTS
+    args = base_parser().parse_args()
+
+    # Load config yaml
+    if args.config:
+        CONFIG_FILE = args.config
+    config = yaml.load(open(CONFIG_FILE))
+    pprint("Loaded YAML config from %s" % CONFIG_FILE)
+
+    pprint("Using direct ElasticSearch broker model")
+    broker = kibbleES.Broker(config)
+
+    orgNo = 0
+    sourceNo = 0
+    for org in broker.organisations():
+        if not args.org or args.org == org.id:
+            pprint("Processing organisation %s" % org.id)
+            orgNo += 1
+
+            # Compile source list
+            # If --age is passed, only append source that either
+            # have never been scanned, or have been scanned more than
+            # N hours ago by any scanner.
+            if args.age:
+                minAge = time.time() - int(args.age) * 3600
+                for source in org.sources(view=args.view):
+                    tooNew = False
+                    if "steps" in source:
+                        for key, step in source["steps"].items():
+                            if "time" in step and step["time"] >= minAge:
+                                tooNew = True
+                                break
+                    if not tooNew:
+                        if not args.source or (args.source == source["sourceID"]):
+                            PENDING_OBJECTS.append(source)
+            else:
+                PENDING_OBJECTS = []
+                for source in org.sources(view=args.view):
+                    if not args.source or (args.source == source["sourceID"]):
+                        PENDING_OBJECTS.append(source)
+                sourceNo += len(PENDING_OBJECTS)
+
+            # Start up some threads equal to number of cores on the box,
+            # but no more than 4. We don't want an IOWait nightmare.
+            threads = []
+            core_count = min((4, int(multiprocessing.cpu_count())))
+            for i in range(0, core_count):
+                sThread = scanThread(broker, org, i + 1, args.type, args.exclude)
+                sThread.start()
+                threads.append(sThread)
+
+            # Wait for them all to finish.
+            for t in threads:
+                t.join()
+
+    pprint(
+        "All done scanning for now, found %i organisations and %i sources to process."
+        % (orgNo, sourceNo)
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/kibble/scanners/mapping.json
+++ b/kibble/scanners/mapping.json
@@ -1,0 +1,455 @@
+{
+		"mappings": {
+			"email": {
+				"properties": {
+					"@version": {
+						"type": "long"
+					},
+					"address": {
+						"type": "string",
+						"index": "not_analyzed"
+					},
+					"date": {
+						"type": "date",
+						"store": true,
+						"format": "yyyy/MM/dd HH:mm:ss"
+					},
+					"hash": {
+						"type": "string",
+                        "index": "not_analyzed"
+					},
+					"id": {
+						"type": "string",
+                        "index": "not_analyzed"
+					},
+					"organisation": {
+						"type": "string",
+                        "index": "not_analyzed"
+					},
+					"sender": {
+						"type": "string",
+                        "index": "not_analyzed"
+					},
+					"sourceID": {
+						"type": "string",
+                        "index": "not_analyzed"
+					},
+					"ts": {
+						"type": "long"
+					}
+				}
+			},
+			"account": {
+				"properties": {
+					"cookie": {
+						"type": "string",
+                        "index": "not_analyzed"
+					},
+					"email": {
+						"type": "string",
+                        "index": "not_analyzed"
+					},
+					"fullname": {
+						"type": "string"
+					},
+					"id": {
+						"type": "string",
+                        "index": "not_analyzed"
+					},
+					"organisation": {
+						"type": "string",
+                        "index": "not_analyzed"
+					},
+					"orgs": {
+						"type": "string"
+					},
+					"password": {
+						"type": "string",
+                        "index": "not_analyzed"
+					},
+					"request_id": {
+						"type": "string",
+                        "index": "not_analyzed"
+					},
+					"screenname": {
+						"type": "string",
+                        "index": "not_analyzed"
+					},
+					"tag": {
+						"type": "string",
+                        "index": "not_analyzed"
+					},
+					"verified": {
+						"type": "boolean"
+					}
+				}
+			},
+			"code_commit": {
+				"properties": {
+					"@version": {
+						"type": "long"
+					},
+					"author_email": {
+						"type": "string",
+						"index": "not_analyzed"
+					},
+					"author_name": {
+						"type": "string",
+                        "index": "not_analyzed"
+					},
+					"committer_email": {
+						"type": "string",
+						"index": "not_analyzed"
+					},
+					"committer_name": {
+						"type": "string",
+                        "index": "not_analyzed"
+					},
+					"date": {
+						"type": "date",
+						"store": true,
+						"format": "yyyy/MM/dd HH:mm:ss"
+					},
+					"deletions": {
+						"type": "long"
+					},
+					"id": {
+						"type": "string",
+                        "index": "not_analyzed"
+					},
+					"insertions": {
+						"type": "long"
+					},
+					"organisation": {
+						"type": "string",
+                        "index": "not_analyzed"
+					},
+					"sourceID": {
+						"type": "string",
+						"index": "not_analyzed"
+					},
+					"source": {
+						"type": "string",
+                        "index": "not_analyzed"
+					},
+					"ts": {
+						"type": "long"
+					},
+					"tsday": {
+						"type": "long"
+					},
+					"vcs": {
+						"type": "string",
+                        "index": "not_analyzed"
+					}
+				}
+			},
+			"code_commit_unique": {
+				"properties": {
+					"@version": {
+						"type": "long"
+					},
+					"author_email": {
+						"type": "string",
+						"index": "not_analyzed"
+					},
+					"author_name": {
+						"type": "string",
+                        "index": "not_analyzed"
+					},
+					"committer_email": {
+						"type": "string",
+						"index": "not_analyzed"
+					},
+					"committer_name": {
+						"type": "string",
+                        "index": "not_analyzed"
+					},
+					"date": {
+						"type": "date",
+						"store": true,
+						"format": "yyyy/MM/dd HH:mm:ss"
+					},
+					"deletions": {
+						"type": "long"
+					},
+					"id": {
+						"type": "string",
+                        "index": "not_analyzed"
+					},
+					"insertions": {
+						"type": "long"
+					},
+					"organisation": {
+						"type": "string",
+                        "index": "not_analyzed"
+					},
+					"sourceID": {
+						"type": "string",
+						"index": "not_analyzed"
+					},
+					"source": {
+						"type": "string",
+                        "index": "not_analyzed"
+					},
+					"ts": {
+						"type": "long"
+					},
+					"tsday": {
+						"type": "long"
+					},
+					"vcs": {
+						"type": "string",
+                        "index": "not_analyzed"
+					}
+				}
+			},
+			"org": {
+				"properties": {
+					"admins": {
+						"type": "string"
+					},
+					"id": {
+						"type": "string",
+                        "index": "not_analyzed"
+					},
+					"name": {
+						"type": "string",
+                        "index": "not_analyzed"
+					},
+					"request_id": {
+						"type": "string",
+                        "index": "not_analyzed"
+					}
+				}
+			},
+			"mailstats": {
+				"properties": {
+					"authors": {
+						"type": "long"
+					},
+					"date": {
+						"type": "date",
+						"store": true,
+						"format": "yyyy/MM/dd HH:mm:ss"
+					},
+					"emails": {
+						"type": "long"
+					},
+					"hash": {
+						"type": "string",
+                        "index": "not_analyzed"
+					},
+					"organisation": {
+						"type": "string",
+                        "index": "not_analyzed"
+					},
+					"sourceID": {
+						"type": "string",
+                        "index": "not_analyzed"
+					},
+					"topics": {
+						"type": "long"
+					}
+				}
+			},
+			"mailtop": {
+				"properties": {
+					"date": {
+						"type": "date",
+						"store": true,
+						"format": "yyyy/MM/dd HH:mm:ss"
+					},
+					"emails": {
+						"type": "long"
+					},
+					"hash": {
+						"type": "string",
+						"index": "not_analyzed"
+					},
+					"id": {
+						"type": "string",
+						"index": "not_analyzed"
+					},
+					"organisation": {
+						"type": "string",
+						"index": "not_analyzed"
+					},
+					"shash": {
+						"type": "string",
+						"index": "not_analyzed"
+					},
+					"sourceID": {
+						"type": "string",
+						"index": "not_analyzed"
+					},
+					"subject": {
+						"type": "string"
+					},
+					"ts": {
+						"type": "long"
+					}
+				}
+			},
+			"source": {
+				"properties": {
+					"default_branch": {
+						"type": "string"
+					},
+					"exception": {
+						"type": "string"
+					},
+					"good": {
+						"type": "boolean"
+					},
+					"sourceID": {
+						"type": "string",
+						"index": "not_analyzed"
+					},
+					"sourceURL": {
+						"type": "string",
+						"index": "not_analyzed"
+					},
+					"organisation": {
+						"type": "string",
+						"index": "not_analyzed"
+					},
+					"sync": {
+						"type": "double"
+					},
+					"tag": {
+						"type": "string",
+						"index": "not_analyzed"
+					},
+					"type": {
+						"type": "string",
+						"index": "not_analyzed"
+					}
+				}
+			},
+			"person": {
+				"properties": {
+					"@version": {
+						"type": "long"
+					},
+					"address": {
+						"type": "string",
+						"index": "not_analyzed"
+					},
+					"email": {
+						"type": "string",
+						"index": "not_analyzed"
+					},
+					"id": {
+						"type": "string",
+						"index": "not_analyzed"
+					},
+					"name": {
+						"type": "string",
+						"index": "not_analyzed"
+					},
+					"organisation": {
+						"type": "string",
+						"index": "not_analyzed"
+					}
+				}
+			},
+			"issue": {
+				"properties": {
+					"assignee": {
+						"type": "string",
+						"index": "not_analyzed"
+					},
+					"changeDate": {
+						"type": "date",
+						"store": true,
+						"format": "yyyy/MM/dd HH:mm:ss"
+					},
+					"closed": {
+						"type": "double"
+					},
+					"closedDate": {
+						"type": "date",
+						"format": "yyyy/MM/dd HH:mm:ss||yyyy/MM/dd||epoch_millis"
+					},
+					"comments": {
+						"type": "long"
+					},
+					"created": {
+						"type": "double"
+					},
+					"createdDate": {
+						"type": "date",
+						"format": "yyyy/MM/dd HH:mm:ss||yyyy/MM/dd||epoch_millis"
+					},
+					"id": {
+						"type": "string",
+						"index": "not_analyzed"
+					},
+					"issueCloser": {
+						"type": "string",
+						"index": "not_analyzed"
+					},
+					"issueCreator": {
+						"type": "string",
+						"index": "not_analyzed"
+					},
+					"key": {
+						"type": "string",
+						"index": "not_analyzed"
+					},
+					"organisation": {
+						"type": "string",
+						"index": "not_analyzed"
+					},
+					"sourceID": {
+						"type": "string",
+						"index": "not_analyzed"
+					},
+					"status": {
+						"type": "string",
+						"index": "not_analyzed"
+					},
+					"title": {
+						"type": "string",
+						"index": "not_analyzed"
+					},
+					"url": {
+						"type": "string",
+						"index": "not_analyzed"
+					}
+				}
+			},
+			"evolution": {
+				"properties": {
+					"blank": {
+						"type": "long"
+					},
+					"comments": {
+						"type": "long"
+					},
+					"cost": {
+						"type": "double"
+					},
+					"loc": {
+						"type": "long"
+					},
+					"organisation": {
+						"type": "string",
+						"index": "not_analyzed"
+					},
+					"sourceID": {
+						"type": "string",
+						"index": "not_analyzed"
+					},
+					"time": {
+						"type": "double"
+					},
+					"years": {
+						"type": "double"
+					}
+				}
+			}
+		}
+
+}

--- a/kibble/scanners/scanners/__init__.py
+++ b/kibble/scanners/scanners/__init__.py
@@ -1,0 +1,61 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""
+This file contains, in execution order, a list of the available
+scanners that Kibble has.
+"""
+
+import importlib
+
+# Define, in order of priority, all scanner plugins we have
+__all__ = [
+    "git-sync",  # This needs to precede other VCS scanners!
+    "git-census",
+    "git-sloc",
+    "git-evolution",
+    "jira",
+    "ponymail",
+    "ponymail-tone",
+    "ponymail-kpe",
+    "pipermail",
+    "github-issues",
+    "bugzilla",
+    "gerrit",
+    "jenkins",
+    "buildbot",
+    "travis",
+    "discourse",
+]
+
+# Import each plugin into a hash called 'scanners'
+scanners = {}
+
+for p in __all__:
+    scanner = importlib.import_module("kibble.scanners.scanners.%s" % p)
+    scanners[p] = scanner
+    # This should ideally be pprint, meh
+    print(
+        "[core]: Loaded plugins/scanners/%s v/%s (%s)"
+        % (p, scanner.version, scanner.title)
+    )
+
+
+def enumerate():
+    """ Returns the scanners as a dictionary, sorted by run-order """
+    for p in __all__:
+        yield (p, scanners[p])

--- a/kibble/scanners/scanners/bugzilla.py
+++ b/kibble/scanners/scanners/bugzilla.py
@@ -1,0 +1,465 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+""" This is the BugZilla scanner plugin for Kible """
+
+import re
+import json
+import time
+import hashlib
+from threading import Thread, Lock
+from kibble.scanners.utils import jsonapi
+import urllib
+
+title = "Scanner for BugZilla"
+version = "0.1.0"
+
+
+def accepts(source):
+    """ Determine if this is a BugZilla source """
+    if source["type"] == "bugzilla":
+        return True
+    if source["type"] == "issuetracker":
+        bz = re.match(
+            r"(https?://\S+?)(/jsonrpc\.cgi)?[\s:?]+(.+)", source["sourceURL"]
+        )
+        if bz:
+            return True
+    return False
+
+
+def getTime(string):
+    return time.mktime(
+        time.strptime(re.sub(r"[zZ]", "", str(string)), "%Y-%m-%dT%H:%M:%S")
+    )
+
+
+def assigned(js):
+    if "items" in js:
+        for item in js["items"]:
+            if item["field"] == "assignee":
+                return True
+    return False
+
+
+def wfi(js):
+    if "items" in js:
+        for item in js["items"]:
+            if item["field"] == "status" and item["toString"] == "Waiting for Infra":
+                return True
+    return False
+
+
+def wfu(js):
+    if "items" in js:
+        for item in js["items"]:
+            if item["field"] == "status" and item["toString"] == "Waiting for user":
+                return True
+    return False
+
+
+def moved(js):
+    if "items" in js:
+        for item in js["items"]:
+            if item["field"] == "Key" and item["toString"].find("INFRA-") != -1:
+                return True
+    return False
+
+
+def wasclosed(js):
+    if "changelog" in js:
+        cjs = js["changelog"]["histories"]
+        for citem in cjs:
+            if "items" in citem:
+                for item in citem["items"]:
+                    if item["field"] == "status" and (
+                        item["toString"] == "Closed" or item["toString"] == "Resolved"
+                    ):
+                        return (True, citem["author"])
+    else:
+        if "items" in js:
+            for item in js["items"]:
+                if item["field"] == "status" and item["toString"] == "Closed":
+                    return (True, None)
+    return (False, None)
+
+
+def resolved(js):
+    if "items" in js:
+        for item in js["items"]:
+            if item["field"] == "resolution" and (
+                item["toString"] != "Pending Closed"
+                and item["toString"] != "Unresolved"
+            ):
+                return True
+    return False
+
+
+def pchange(js):
+    if "items" in js:
+        for item in js["items"]:
+            if item["field"] == "priority":
+                return True
+    return False
+
+
+def scanTicket(bug, KibbleBit, source, openTickets, u, dom):
+    try:
+        key = bug["id"]
+        dhash = hashlib.sha224(
+            ("%s-%s-%s" % (source["organisation"], source["sourceURL"], key)).encode(
+                "ascii", errors="replace"
+            )
+        ).hexdigest()
+        found = KibbleBit.exists("issue", dhash)
+        parseIt = False
+        if not found:
+            parseIt = True
+        else:
+            ticket = KibbleBit.get("issue", dhash)
+            if ticket["status"] == "closed" and key in openTickets:
+                KibbleBit.pprint("Ticket was reopened, reparsing")
+                parseIt = True
+            elif ticket["status"] == "open" and not key in openTickets:
+                KibbleBit.pprint("Ticket was recently closed, parsing it")
+                parseIt = True
+            else:
+                pass
+                # print("Ticket hasn't changed, ignoring...")
+
+        if parseIt:
+            KibbleBit.pprint("Parsing data from BugZilla for #%s" % key)
+
+            params = {"ids": [int(key)], "limit": 0}
+            if (
+                source["creds"]
+                and "username" in source["creds"]
+                and source["creds"]["username"]
+                and len(source["creds"]["username"]) > 0
+            ):
+                params["Bugzilla_login"] = source["creds"]["username"]
+                params["Bugzilla_password"] = source["creds"]["password"]
+            ticketsURL = "%s?method=Bug.get&params=[%s]" % (
+                u,
+                urllib.parse.quote(json.dumps(params)),
+            )
+
+            js = jsonapi.get(ticketsURL)
+            js = js["result"]["bugs"][0]
+            creator = {"name": bug["creator"], "email": js["creator"]}
+            closer = {}
+            cd = getTime(js["creation_time"])
+            rd = None
+            status = "open"
+            if js["status"] in ["CLOSED", "RESOLVED"]:
+                status = "closed"
+                KibbleBit.pprint("%s was closed, finding out who did that" % key)
+                ticketsURL = "%s?method=Bug.history&params=[%s]" % (
+                    u,
+                    urllib.parse.quote(json.dumps(params)),
+                )
+                hjs = jsonapi.get(ticketsURL)
+                history = hjs["result"]["bugs"][0]["history"]
+                for item in history:
+                    for change in item["changes"]:
+                        if (
+                            change["field_name"] == "status"
+                            and "added" in change
+                            and change["added"] in ["CLOSED", "RESOLVED"]
+                        ):
+                            rd = getTime(item["when"])
+                            closer = {"name": item["who"], "email": item["who"]}
+                            break
+            KibbleBit.pprint("Counting comments for %s..." % key)
+            ticketsURL = "%s?method=Bug.comments&params=[%s]" % (
+                u,
+                urllib.parse.quote(json.dumps(params)),
+            )
+            hjs = jsonapi.get(ticketsURL)
+            comments = len(hjs["result"]["bugs"][str(key)]["comments"])
+
+            title = bug["summary"]
+            del params["ids"]
+            if closer:
+
+                pid = hashlib.sha1(
+                    ("%s%s" % (source["organisation"], closer["email"])).encode(
+                        "ascii", errors="replace"
+                    )
+                ).hexdigest()
+                found = KibbleBit.exists("person", pid)
+                if not found:
+                    params["names"] = [closer["email"]]
+                    ticketsURL = "%s?method=User.get&params=[%s]" % (
+                        u,
+                        urllib.parse.quote(json.dumps(params)),
+                    )
+
+                    try:
+                        ujs = jsonapi.get(ticketsURL)
+                        displayName = ujs["result"]["users"][0]["real_name"]
+                    except:
+                        displayName = closer["email"]
+                    if displayName and len(displayName) > 0:
+                        # Add to people db
+
+                        jsp = {
+                            "name": displayName,
+                            "email": closer["email"],
+                            "organisation": source["organisation"],
+                            "id": pid,
+                        }
+                        # print("Updating person DB for closer: %s (%s)" % (displayName, closerEmail))
+                        KibbleBit.index("person", pid, jsp)
+
+            if creator:
+                pid = hashlib.sha1(
+                    ("%s%s" % (source["organisation"], creator["email"])).encode(
+                        "ascii", errors="replace"
+                    )
+                ).hexdigest()
+                found = KibbleBit.exists("person", pid)
+                if not found:
+                    if not creator["name"]:
+                        params["names"] = [creator["email"]]
+                        ticketsURL = "%s?method=User.get&params=[%s]" % (
+                            u,
+                            urllib.parse.quote(json.dumps(params)),
+                        )
+                        try:
+                            ujs = jsonapi.get(ticketsURL)
+                            creator["name"] = ujs["result"]["users"][0]["real_name"]
+                        except:
+                            creator["name"] = creator["email"]
+                    if creator["name"] and len(creator["name"]) > 0:
+                        # Add to people db
+
+                        jsp = {
+                            "name": creator["name"],
+                            "email": creator["email"],
+                            "organisation": source["organisation"],
+                            "id": pid,
+                        }
+                        KibbleBit.index("person", pid, jsp)
+
+            jso = {
+                "id": dhash,
+                "key": key,
+                "organisation": source["organisation"],
+                "sourceID": source["sourceID"],
+                "url": "%s/show_bug.cgi?id=%s" % (dom, key),
+                "status": status,
+                "created": cd,
+                "closed": rd,
+                "issuetype": "issue",
+                "issueCloser": closer["email"] if "email" in closer else None,
+                "createdDate": time.strftime("%Y/%m/%d %H:%M:%S", time.gmtime(cd)),
+                "closedDate": time.strftime("%Y/%m/%d %H:%M:%S", time.gmtime(rd))
+                if rd
+                else None,
+                "changeDate": time.strftime(
+                    "%Y/%m/%d %H:%M:%S", time.gmtime(rd if rd else cd)
+                ),
+                "assignee": None,
+                "issueCreator": creator["email"],
+                "comments": comments,
+                "title": title,
+            }
+            KibbleBit.append("issue", jso)
+            time.sleep(0.5)  # BugZilla is notoriously slow. Maybe remove this later
+        return True
+    except Exception as err:
+        KibbleBit.pprint(err)
+        return False
+
+
+class bzThread(Thread):
+    def __init__(self, KibbleBit, source, block, pt, ot, u, dom):
+        super(bzThread, self).__init__()
+        self.KibbleBit = KibbleBit
+        self.source = source
+        self.block = block
+        self.pendingTickets = pt
+        self.openTickets = ot
+        self.u = u
+        self.dom = dom
+
+    def run(self):
+        badOnes = 0
+
+        while len(self.pendingTickets) > 0 and badOnes <= 50:
+            if len(self.pendingTickets) % 10 == 0:
+                self.KibbleBit.pprint(
+                    "%u elements left to count" % len(self.pendingTickets)
+                )
+            self.block.acquire()
+            try:
+                rl = self.pendingTickets.pop(0)
+            except Exception as err:  # list empty, likely
+                self.block.release()
+                return
+            if not rl:
+                self.block.release()
+                return
+            self.block.release()
+            if not scanTicket(
+                rl, self.KibbleBit, self.source, self.openTickets, self.u, self.dom
+            ):
+                self.KibbleBit.pprint("Ticket %s seems broken, skipping" % rl["id"])
+                badOnes += 1
+                if badOnes > 50:
+                    self.KibbleBit.pprint("Too many errors, bailing!")
+                    self.source["steps"]["issues"] = {
+                        "time": time.time(),
+                        "status": "Too many errors while parsing at "
+                        + time.strftime("%Y/%m/%d %H:%M:%S", time.gmtime(time.time())),
+                        "running": False,
+                        "good": False,
+                    }
+                    self.KibbleBit.updateSource(self.source)
+                    return
+            else:
+                badOnes = 0
+
+
+def scan(KibbleBit, source):
+    path = source["sourceID"]
+    url = source["sourceURL"]
+
+    source["steps"]["issues"] = {
+        "time": time.time(),
+        "status": "Parsing BugZilla changes...",
+        "running": True,
+        "good": True,
+    }
+    KibbleBit.updateSource(source)
+
+    bz = re.match(r"(https?://\S+?)(/jsonrpc\.cgi)?[\s:?]+(.+)", url)
+    if bz:
+        if (
+            source["creds"]
+            and "username" in source["creds"]
+            and source["creds"]["username"]
+            and len(source["creds"]["username"]) > 0
+        ):
+            creds = "%s:%s" % (source["creds"]["username"], source["creds"]["password"])
+        badOnes = 0
+        pendingTickets = []
+        openTickets = []
+
+        # Get base URL, list and domain to parse
+        dom = bz.group(1)
+        dom = re.sub(r"/+$", "", dom)
+        u = "%s/jsonrpc.cgi" % dom
+        instance = bz.group(3)
+        lastTicket = 0
+
+        params = {
+            "product": [instance],
+            "status": [
+                "RESOLVED",
+                "CLOSED",
+                "NEW",
+                "UNCOMFIRMED",
+                "ASSIGNED",
+                "REOPENED",
+                "VERIFIED",
+            ],
+            "include_fields": ["id", "creation_time", "status", "summary", "creator"],
+            "limit": 10000,
+            "offset": 1,
+        }
+        # If * is requested, just omit the product name
+        if instance == "*":
+            params = {
+                "status": [
+                    "RESOLVED",
+                    "CLOSED",
+                    "NEW",
+                    "UNCOMFIRMED",
+                    "ASSIGNED",
+                    "REOPENED",
+                    "VERIFIED",
+                ],
+                "include_fields": [
+                    "id",
+                    "creation_time",
+                    "status",
+                    "summary",
+                    "creator",
+                ],
+                "limit": 10000,
+                "offset": 1,
+            }
+
+        ticketsURL = "%s?method=Bug.search&params=[%s]" % (
+            u,
+            urllib.parse.quote(json.dumps(params)),
+        )
+
+        while True:
+            try:
+                js = jsonapi.get(ticketsURL, auth=creds)
+            except:
+                KibbleBit.pprint("Couldn't fetch more tickets, bailing")
+                break
+
+            if len(js["result"]["bugs"]) > 0:
+                KibbleBit.pprint(
+                    "%s: Found %u tickets..."
+                    % (
+                        source["sourceURL"],
+                        ((params.get("offset", 1) - 1) + len(js["result"]["bugs"])),
+                    )
+                )
+                for bug in js["result"]["bugs"]:
+                    pendingTickets.append(bug)
+                    if not bug["status"] in ["RESOLVED", "CLOSED"]:
+                        openTickets.append(bug["id"])
+                params["offset"] += 10000
+                ticketsURL = "%s?method=Bug.search&params=[%s]" % (
+                    u,
+                    urllib.parse.quote(json.dumps(params)),
+                )
+            else:
+                KibbleBit.pprint("No more tickets left to scan")
+                break
+
+        KibbleBit.pprint(
+            "Found %u open tickets, %u closed."
+            % (len(openTickets), len(pendingTickets) - len(openTickets))
+        )
+
+        badOnes = 0
+        block = Lock()
+        threads = []
+        for i in range(0, 4):
+            t = bzThread(KibbleBit, source, block, pendingTickets, openTickets, u, dom)
+            threads.append(t)
+            t.start()
+
+        for t in threads:
+            t.join()
+
+        source["steps"]["issues"] = {
+            "time": time.time(),
+            "status": "Issue tracker (BugZilla) successfully scanned at "
+            + time.strftime("%Y/%m/%d %H:%M:%S", time.gmtime(time.time())),
+            "running": False,
+            "good": True,
+        }
+        KibbleBit.updateSource(source)

--- a/kibble/scanners/scanners/buildbot.py
+++ b/kibble/scanners/scanners/buildbot.py
@@ -1,0 +1,281 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import time
+import datetime
+import re
+import hashlib
+import threading
+
+from kibble.scanners.utils import jsonapi
+
+"""
+This is the Kibble Buildbot scanner plugin.
+"""
+
+title = "Scanner for Buildbot"
+version = "0.1.0"
+
+
+def accepts(source):
+    """ Determines whether we want to handle this source """
+    if source["type"] == "buildbot":
+        return True
+    return False
+
+
+def scanJob(KibbleBit, source, job, creds):
+    """ Scans a single job for activity """
+    NOW = int(datetime.datetime.utcnow().timestamp())
+    dhash = hashlib.sha224(
+        ("%s-%s-%s" % (source["organisation"], source["sourceID"], job)).encode(
+            "ascii", errors="replace"
+        )
+    ).hexdigest()
+    found = True
+    doc = None
+    parseIt = False
+    found = KibbleBit.exists("cijob", dhash)
+
+    jobURL = "%s/json/builders/%s/builds/_all" % (source["sourceURL"], job)
+    KibbleBit.pprint(jobURL)
+    jobjson = jsonapi.get(jobURL, auth=creds)
+
+    # If valid JSON, ...
+    if jobjson:
+        for buildno, data in jobjson.items():
+            buildhash = hashlib.sha224(
+                (
+                    "%s-%s-%s-%s"
+                    % (source["organisation"], source["sourceID"], job, buildno)
+                ).encode("ascii", errors="replace")
+            ).hexdigest()
+            builddoc = None
+            try:
+                builddoc = KibbleBit.get("ci_build", buildhash)
+            except:
+                pass
+
+            # If this build already completed, no need to parse it again
+            if builddoc and builddoc.get("completed", False):
+                continue
+
+            KibbleBit.pprint(
+                "[%s-%s] This is new or pending, analyzing..." % (job, buildno)
+            )
+
+            completed = True if "currentStep" in data else False
+
+            # Get build status (success, failed, canceled etc)
+            status = "building"
+            if "successful" in data.get("text", []):
+                status = "success"
+            if "failed" in data.get("text", []):
+                status = "failed"
+            if "exception" in data.get("text", []):
+                status = "aborted"
+
+            DUR = 0
+            # Calc when the build finished
+            if completed and len(data.get("times", [])) == 2 and data["times"][1]:
+                FIN = data["times"][1]
+                DUR = FIN - data["times"][0]
+            else:
+                FIN = 0
+
+            doc = {
+                # Build specific data
+                "id": buildhash,
+                "date": time.strftime("%Y/%m/%d %H:%M:%S", time.gmtime(FIN)),
+                "buildID": buildno,
+                "completed": completed,
+                "duration": DUR * 1000,  # Buildbot does seconds, not milis
+                "job": job,
+                "jobURL": "%s/builders/%s" % (source["sourceURL"], job),
+                "status": status,
+                "started": int(data["times"][0]),
+                "ci": "buildbot",
+                # Standard docs values
+                "sourceID": source["sourceID"],
+                "organisation": source["organisation"],
+                "upsert": True,
+            }
+            KibbleBit.append("ci_build", doc)
+        # Yay, it worked!
+        return True
+
+    # Boo, it failed!
+    KibbleBit.pprint("Fetching job data failed!")
+    return False
+
+
+class buildbotThread(threading.Thread):
+    """ Generic thread class for scheduling multiple scans at once """
+
+    def __init__(self, block, KibbleBit, source, creds, jobs):
+        super(buildbotThread, self).__init__()
+        self.block = block
+        self.KibbleBit = KibbleBit
+        self.creds = creds
+        self.source = source
+        self.jobs = jobs
+
+    def run(self):
+        badOnes = 0
+        while len(self.jobs) > 0 and badOnes <= 50:
+            self.block.acquire()
+            try:
+                job = self.jobs.pop(0)
+            except Exception as err:
+                self.block.release()
+                return
+            if not job:
+                self.block.release()
+                return
+            self.block.release()
+            if not scanJob(self.KibbleBit, self.source, job, self.creds):
+                self.KibbleBit.pprint("[%s] This borked, trying another one" % job)
+                badOnes += 1
+                if badOnes > 100:
+                    self.KibbleBit.pprint("Too many errors, bailing!")
+                    self.source["steps"]["ci"] = {
+                        "time": time.time(),
+                        "status": "Too many errors while parsing at "
+                        + time.strftime("%Y/%m/%d %H:%M:%S", time.gmtime(time.time())),
+                        "running": False,
+                        "good": False,
+                    }
+                    self.KibbleBit.updateSource(self.source)
+                    return
+            else:
+                badOnes = 0
+
+
+def scan(KibbleBit, source):
+    # Simple URL check
+    buildbot = re.match(r"(https?://.+)", source["sourceURL"])
+    if buildbot:
+
+        source["steps"]["ci"] = {
+            "time": time.time(),
+            "status": "Parsing Buildbot job changes...",
+            "running": True,
+            "good": True,
+        }
+        KibbleBit.updateSource(source)
+
+        badOnes = 0
+        pendingJobs = []
+        KibbleBit.pprint("Parsing Buildbot activity at %s" % source["sourceURL"])
+        source["steps"]["ci"] = {
+            "time": time.time(),
+            "status": "Downloading changeset",
+            "running": True,
+            "good": True,
+        }
+        KibbleBit.updateSource(source)
+
+        # Buildbot may neeed credentials
+        creds = None
+        if (
+            source["creds"]
+            and "username" in source["creds"]
+            and source["creds"]["username"]
+            and len(source["creds"]["username"]) > 0
+        ):
+            creds = "%s:%s" % (source["creds"]["username"], source["creds"]["password"])
+
+        # Get the job list
+        sURL = source["sourceURL"]
+        KibbleBit.pprint("Getting job list...")
+        builders = jsonapi.get("%s/json/builders" % sURL, auth=creds)
+
+        # Save queue snapshot
+        NOW = int(datetime.datetime.utcnow().timestamp())
+        queuehash = hashlib.sha224(
+            (
+                "%s-%s-queue-%s"
+                % (source["organisation"], source["sourceID"], int(time.time()))
+            ).encode("ascii", errors="replace")
+        ).hexdigest()
+
+        # Scan queue items
+        blocked = 0
+        stuck = 0
+        totalqueuetime = 0
+        labelQueuedBuilds = {}
+        queueSize = 0
+        actualQueueSize = 0
+        building = 0
+        jobs = []
+
+        for builder, data in builders.items():
+            jobs.append(builder)
+            if data["state"] == "building":
+                building += 1
+            if data.get("pendingBuilds", 0) > 0:
+                # All queued items, even offlined builders
+                actualQueueSize += data.get("pendingBuilds", 0)
+                # Only queues with an online builder (actually waiting stuff)
+                if data["state"] == "building":
+                    queueSize += data.get("pendingBuilds", 0)
+                    blocked += data.get("pendingBuilds", 0)  # Blocked by running builds
+                # Stuck builds (iow no builder available)
+                if data["state"] == "offline":
+                    stuck += data.get("pendingBuilds", 0)
+
+        # Write up a queue doc
+        queuedoc = {
+            "id": queuehash,
+            "date": time.strftime("%Y/%m/%d %H:%M:%S", time.gmtime(NOW)),
+            "time": NOW,
+            "size": queueSize,
+            "blocked": blocked,
+            "stuck": stuck,
+            "building": building,
+            "ci": "buildbot",
+            # Standard docs values
+            "sourceID": source["sourceID"],
+            "organisation": source["organisation"],
+            "upsert": True,
+        }
+        KibbleBit.append("ci_queue", queuedoc)
+
+        KibbleBit.pprint("Found %u builders in Buildbot" % len(jobs))
+
+        threads = []
+        block = threading.Lock()
+        KibbleBit.pprint("Scanning jobs using 4 sub-threads")
+        for i in range(0, 4):
+            t = buildbotThread(block, KibbleBit, source, creds, jobs)
+            threads.append(t)
+            t.start()
+
+        for t in threads:
+            t.join()
+
+        # We're all done, yaay
+        KibbleBit.pprint("Done scanning %s" % source["sourceURL"])
+
+        source["steps"]["ci"] = {
+            "time": time.time(),
+            "status": "Buildbot successfully scanned at "
+            + time.strftime("%Y/%m/%d %H:%M:%S", time.gmtime(time.time())),
+            "running": False,
+            "good": True,
+        }
+        KibbleBit.updateSource(source)

--- a/kibble/scanners/scanners/discourse.py
+++ b/kibble/scanners/scanners/discourse.py
@@ -1,0 +1,345 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import time
+import datetime
+import re
+import hashlib
+import threading
+import os
+
+from kibble.scanners.utils import jsonapi
+
+"""
+This is the Kibble Discourse scanner plugin.
+"""
+
+title = "Scanner for Discourse Forums"
+version = "0.1.0"
+
+
+def accepts(source):
+    """ Determines whether we want to handle this source """
+    if source["type"] == "discourse":
+        return True
+    return False
+
+
+def scanJob(KibbleBit, source, cat, creds):
+    """ Scans a single discourse category for activity """
+    NOW = int(datetime.datetime.utcnow().timestamp())
+
+    # Get $discourseURL/c/$catID
+
+    catURL = os.path.join(source["sourceURL"], "c/%s" % cat["id"])
+    KibbleBit.pprint("Scanning Discourse category '%s' at %s" % (cat["slug"], catURL))
+
+    page = 0
+    allUsers = {}
+
+    # For each paginated result (up to page 100), check for changes
+    while page < 100:
+        pcatURL = "%s?page=%u" % (catURL, page)
+        catjson = jsonapi.get(pcatURL, auth=creds)
+        page += 1
+
+        if catjson:
+
+            # If we hit an empty list (no more topics), just break the loop.
+            if not catjson["topic_list"]["topics"]:
+                break
+
+            # First (if we have data), we should store the known users
+            # Since discourse hides the email (obviously!), we'll have to
+            # fake one to generate an account.
+            fakeDomain = "foo.discourse"
+            m = re.match(r"https?://([-a-zA-Z0-9.]+)", source["sourceURL"])
+            if m:
+                fakeDomain = m.group(1)
+            for user in catjson["users"]:
+                # Fake email address, compute deterministic ID
+                email = "%s@%s" % (user["username"], fakeDomain)
+                dhash = hashlib.sha224(
+                    (
+                        "%s-%s-%s"
+                        % (source["organisation"], source["sourceURL"], email)
+                    ).encode("ascii", errors="replace")
+                ).hexdigest()
+
+                # Construct a very sparse user document
+                userDoc = {
+                    "id": dhash,
+                    "organisation": source["organisation"],
+                    "name": user["username"],
+                    "email": email,
+                }
+
+                # Store user-ID-to-username mapping for later
+                allUsers[user["id"]] = userDoc
+
+                # Store it (or, queue storage) unless it exists.
+                # We don't wanna override better data, so we check if
+                # it's there first.
+                if not KibbleBit.exists("person", dhash):
+                    KibbleBit.append("person", userDoc)
+
+            # Now, for each topic, we'll store a topic document
+            for topic in catjson["topic_list"]["topics"]:
+
+                # Calculate topic ID
+                dhash = hashlib.sha224(
+                    (
+                        "%s-%s-topic-%s"
+                        % (source["organisation"], source["sourceURL"], topic["id"])
+                    ).encode("ascii", errors="replace")
+                ).hexdigest()
+
+                # Figure out when topic was created and updated
+                CreatedDate = datetime.datetime.strptime(
+                    topic["created_at"], "%Y-%m-%dT%H:%M:%S.%fZ"
+                ).timestamp()
+                if topic.get("last_posted_at"):
+                    UpdatedDate = datetime.datetime.strptime(
+                        topic["last_posted_at"], "%Y-%m-%dT%H:%M:%S.%fZ"
+                    ).timestamp()
+                else:
+                    UpdatedDate = 0
+
+                # Determine whether we should scan this topic or continue to the next one.
+                # We'll do this by seeing if the topic already exists and has no changes or not.
+                if KibbleBit.exists("forum_topic", dhash):
+                    fdoc = KibbleBit.get("forum_topic", dhash)
+                    # If update in the old doc was >= current update timestamp, skip the topic
+                    if fdoc["updated"] >= UpdatedDate:
+                        continue
+
+                # Assuming we need to scan this, start by making the base topic document
+                topicdoc = {
+                    "id": dhash,
+                    "sourceID": source["sourceID"],
+                    "organisation": source["organisation"],
+                    "type": "discourse",
+                    "category": cat["slug"],
+                    "title": topic["title"],
+                    "creator": allUsers[topic["posters"][0]["user_id"]]["id"],
+                    "creatorName": allUsers[topic["posters"][0]["user_id"]]["name"],
+                    "created": CreatedDate,
+                    "createdDate": time.strftime(
+                        "%Y/%m/%d %H:%M:%S", time.gmtime(CreatedDate)
+                    ),
+                    "updated": UpdatedDate,
+                    "solved": False,  # Discourse doesn't have this notion, but other forums might.
+                    "posts": topic["posts_count"],
+                    "views": topic["views"],
+                    "url": source["sourceURL"]
+                    + "/t/%s/%s" % (topic["slug"], topic["id"]),
+                }
+
+                KibbleBit.append("forum_topic", topicdoc)
+                KibbleBit.pprint("%s is new or changed, scanning" % topicdoc["url"])
+
+                # Now grab all the individual replies/posts
+                # Remember to not have it count as a visit!
+                pURL = "%s?track_visit=false&forceLoad=true" % topicdoc["url"]
+                pjson = jsonapi.get(pURL, auth=creds)
+
+                posts = pjson["post_stream"]["posts"]
+
+                # For each post/reply, construct a forum_entry document
+                KibbleBit.pprint("%s has %u posts" % (pURL, len(posts)))
+                for post in posts:
+                    phash = hashlib.sha224(
+                        (
+                            "%s-%s-post-%s"
+                            % (source["organisation"], source["sourceURL"], post["id"])
+                        ).encode("ascii", errors="replace")
+                    ).hexdigest()
+                    uname = (
+                        post.get("name", post["username"]) or post["username"]
+                    )  # Hack to get longest non-zero value
+
+                    # Find the hash of the person who posted it
+                    # We may know them, or we may have to store them.
+                    # If we have better info now (full name), re-store
+                    if (
+                        post["user_id"] in allUsers
+                        and allUsers[post["user_id"]]["name"] == uname
+                    ):
+                        uhash = allUsers[post["user_id"]]["id"]
+                    else:
+                        # Same as before, fake email, store...
+                        email = "%s@%s" % (post["username"], fakeDomain)
+                        uhash = hashlib.sha224(
+                            (
+                                "%s-%s-%s"
+                                % (source["organisation"], source["sourceURL"], email)
+                            ).encode("ascii", errors="replace")
+                        ).hexdigest()
+
+                        # Construct a very sparse user document
+                        userDoc = {
+                            "id": uhash,
+                            "organisation": source["organisation"],
+                            "name": uname,
+                            "email": email,
+                        }
+
+                        # Store user-ID-to-username mapping for later
+                        allUsers[user["id"]] = userDoc
+
+                        # Store it (or, queue storage)
+                        KibbleBit.append("person", userDoc)
+
+                    # Get post date
+                    CreatedDate = datetime.datetime.strptime(
+                        post["created_at"], "%Y-%m-%dT%H:%M:%S.%fZ"
+                    ).timestamp()
+
+                    # Store the post/reply document
+                    pdoc = {
+                        "id": phash,
+                        "sourceID": source["sourceID"],
+                        "organisation": source["organisation"],
+                        "type": "discourse",
+                        "creator": uhash,
+                        "created": CreatedDate,
+                        "createdDate": time.strftime(
+                            "%Y/%m/%d %H:%M:%S", time.gmtime(CreatedDate)
+                        ),
+                        "topic": dhash,
+                        "post_id": post["id"],
+                        "text": post["cooked"],
+                        "url": topicdoc["url"],
+                    }
+                    KibbleBit.append("forum_post", pdoc)
+        else:
+            KibbleBit.pprint("Fetching discourse data failed!")
+            return False
+    return True
+
+
+class discourseThread(threading.Thread):
+    """ Generic thread class for scheduling multiple scans at once """
+
+    def __init__(self, block, KibbleBit, source, creds, jobs):
+        super(discourseThread, self).__init__()
+        self.block = block
+        self.KibbleBit = KibbleBit
+        self.creds = creds
+        self.source = source
+        self.jobs = jobs
+
+    def run(self):
+        badOnes = 0
+        while len(self.jobs) > 0 and badOnes <= 50:
+            self.block.acquire()
+            try:
+                job = self.jobs.pop(0)
+            except Exception as err:
+                self.block.release()
+                return
+            if not job:
+                self.block.release()
+                return
+            self.block.release()
+            if not scanJob(self.KibbleBit, self.source, job, self.creds):
+                self.KibbleBit.pprint(
+                    "[%s] This borked, trying another one" % job["name"]
+                )
+                badOnes += 1
+                if badOnes > 10:
+                    self.KibbleBit.pprint("Too many errors, bailing!")
+                    self.source["steps"]["forum"] = {
+                        "time": time.time(),
+                        "status": "Too many errors while parsing at "
+                        + time.strftime("%Y/%m/%d %H:%M:%S", time.gmtime(time.time())),
+                        "running": False,
+                        "good": False,
+                    }
+                    self.KibbleBit.updateSource(self.source)
+                    return
+            else:
+                badOnes = 0
+
+
+def scan(KibbleBit, source):
+    # Simple URL check
+    discourse = re.match(r"(https?://.+)", source["sourceURL"])
+    if discourse:
+
+        source["steps"]["forum"] = {
+            "time": time.time(),
+            "status": "Parsing Discourse topics...",
+            "running": True,
+            "good": True,
+        }
+        KibbleBit.updateSource(source)
+
+        badOnes = 0
+        pendingJobs = []
+        KibbleBit.pprint("Parsing Discourse activity at %s" % source["sourceURL"])
+        source["steps"]["forum"] = {
+            "time": time.time(),
+            "status": "Downloading changeset",
+            "running": True,
+            "good": True,
+        }
+        KibbleBit.updateSource(source)
+
+        # Discourse may neeed credentials (if basic auth)
+        creds = None
+        if (
+            source["creds"]
+            and "username" in source["creds"]
+            and source["creds"]["username"]
+            and len(source["creds"]["username"]) > 0
+        ):
+            creds = "%s:%s" % (source["creds"]["username"], source["creds"]["password"])
+
+        # Get the list of categories
+        sURL = source["sourceURL"]
+        KibbleBit.pprint("Getting categories...")
+        catjs = jsonapi.get("%s/categories_and_latest" % sURL, auth=creds)
+
+        # Directly assign the category list as pending jobs queue, ezpz.
+        pendingJobs = catjs["category_list"]["categories"]
+
+        KibbleBit.pprint("Found %u categories" % len(pendingJobs))
+
+        # Now fire off 4 threads to parse the categories
+        threads = []
+        block = threading.Lock()
+        KibbleBit.pprint("Scanning jobs using 4 sub-threads")
+        for i in range(0, 4):
+            t = discourseThread(block, KibbleBit, source, creds, pendingJobs)
+            threads.append(t)
+            t.start()
+
+        for t in threads:
+            t.join()
+
+        # We're all done, yaay
+        KibbleBit.pprint("Done scanning %s" % source["sourceURL"])
+
+        source["steps"]["forum"] = {
+            "time": time.time(),
+            "status": "Discourse successfully scanned at "
+            + time.strftime("%Y/%m/%d %H:%M:%S", time.gmtime(time.time())),
+            "running": False,
+            "good": True,
+        }
+        KibbleBit.updateSource(source)

--- a/kibble/scanners/scanners/gerrit.py
+++ b/kibble/scanners/scanners/gerrit.py
@@ -1,0 +1,258 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import re
+import requests
+import hashlib
+from dateutil import parser
+import time
+import json
+
+title = "Scanner for Gerrit Code Review"
+version = "0.1.1"
+
+
+CHANGES_URL = "%s/changes/%s"
+PROJECT_LIST_URL = "%s/projects/"
+ACCOUNTS_URL = "%s/accounts/%d"
+COMMIT_ID_RE = re.compile("    Change-Id: (.*)")
+
+
+def accepts(source):
+    """ Do we accept this source?? """
+    if source["type"] == "gerrit":
+        return True
+    return False
+
+
+def getjson(response):
+    response.raise_for_status()
+    return json.loads(response.text[4:])
+
+
+def get(url, params=None):
+    resp = requests.get(url, params=params)
+    return getjson(resp)
+
+
+def changes(base_url, params=None):
+    return get(CHANGES_URL % (base_url, ""), params=params)
+
+
+def change_details(base_url, change):
+    if isinstance(change, dict):
+        id = change["change_id"]
+    else:
+        id = change
+
+    return get(CHANGES_URL % (base_url, id) + "/detail")
+
+
+def get_commit_id(commit_message):
+    all = COMMIT_ID_RE.findall(commit_message)
+    if all:
+        return all[0]
+    return None
+
+
+def get_all(base_url, f, params={}):
+    acc = []
+
+    while True:
+        items = f(base_url, params=params)
+        if not items:
+            break
+
+        acc.extend(items)
+        params.update({"start": len(acc)})
+
+    return acc
+
+
+def format_date(d, epoch=False):
+    if not d:
+        return
+    parsed = parser.parse(d)
+
+    if epoch:
+        return time.mktime(parsed.timetuple())
+
+    return time.strftime("%Y/%m/%d %H:%M:%S", parsed.timetuple())
+
+
+def make_hash(repo, change):
+    return hashlib.sha224(
+        (
+            "%s-%s-%s" % (repo["organisation"], repo["sourceID"], change["change_id"])
+        ).encode("ascii", errors="replace")
+    ).hexdigest()
+
+
+def is_closed(change):
+    return change["status"] == "MERGED" or change["status"] == "ABANDONED"
+
+
+def make_issue(repo, base_url, change):
+    key = change["change_id"]
+    dhash = make_hash(repo, change)
+
+    closed_date = None
+    if is_closed(change):
+        closed_date = change["updated"]
+
+    if not "email" in change["owner"]:
+        change["owner"]["email"] = "%u@invalid.gerrit" % change["owner"]["_account_id"]
+    owner_email = change["owner"]["email"]
+
+    messages = []
+    for message in change.get("messages", []):
+        messages.append(message.get("message", ""))
+
+    return {
+        "id": dhash,
+        "key": key,
+        "organisation": repo["organisation"],
+        "sourceID": repo["sourceID"],
+        "url": base_url + "/#/q/" + key,
+        "status": change["status"],
+        "created": format_date(change["created"], epoch=True),
+        "closed": format_date(closed_date, epoch=True),
+        "issueCloser": owner_email,
+        "createdDate": format_date(change["created"]),
+        "closedDate": format_date(closed_date),
+        "changeDate": format_date(closed_date if closed_date else change["created"]),
+        "assignee": owner_email,
+        "issueCreator": owner_email,
+        "comments": len(messages),
+        "title": change["subject"],
+    }
+
+
+def make_person(repo, raw_person):
+    email = raw_person["email"]
+    id = hashlib.sha1(
+        ("%s%s" % (repo["organisation"], email)).encode("ascii", errors="replace")
+    ).hexdigest()
+    return {
+        "email": email,
+        "id": id,
+        "organisation": repo["organisation"],
+        "name": raw_person["name"]
+        if "name" in raw_person
+        else "%u" % raw_person["_account_id"],
+    }
+
+
+def update_issue(KibbleBit, issue):
+    id = issue["id"]
+    KibbleBit.pprint("Updating issue: " + id)
+    KibbleBit.index("issue", id, issue)
+
+
+def update_person(KibbleBit, person):
+    KibbleBit.pprint("Updating person: " + person["name"] + " - " + person["email"])
+    KibbleBit.index("person", person["id"], {"doc": person, "doc_as_upsert": True})
+
+
+def status_changed(stored_change, change):
+    if not stored_change or not change:
+        return True
+    return stored_change["status"] != change["status"]
+
+
+def scan(KibbleBit, source):
+    source["steps"]["issues"] = {
+        "time": time.time(),
+        "status": "Analyzing Gerrit tickets...",
+        "running": True,
+        "good": True,
+    }
+    KibbleBit.updateSource(source)
+
+    url = source["sourceURL"]
+    # Try matching foo.bar/r/project/subfoo
+    m = re.match(r"(.+://.+?/r)/(.+)", url)
+    if m:
+        base_url = m.group(1)
+        project_name = m.group(2)
+    # Fall back to old splitty split
+    else:
+        url = re.sub(r"^git://", "http://", url)
+        source_parts = url.split("/")
+        project_name = source_parts[-1]
+        base_url = "/".join(source_parts[:-1])  # remove the trailing /blah/
+
+    # TODO: figure out branch from current checkout
+    q = (
+        '(is:open OR is:new OR is:closed OR is:merged OR is:abandoned) AND project:"%s"'
+        % project_name
+    )
+    all_changes = get_all(
+        base_url, changes, {"q": q, "o": ["LABELS", "DETAILED_ACCOUNTS"]}
+    )
+
+    print("Found " + str(len(all_changes)) + " changes for project: " + project_name)
+
+    people = {}
+    for change in all_changes:
+        try:
+            # TODO: check if needs updating here before getting details
+            dhash = make_hash(source, change)
+
+            stored_change = None
+            if KibbleBit.exists("issue", dhash):
+                stored_change = KibbleBit.get("issue", dhash)
+
+            if not status_changed(stored_change, change):
+                # print("change %s seen already and status unchanged. Skipping." %
+                #      change['change_id'])
+                continue
+
+            details = change_details(base_url, change)
+
+            issue_doc = make_issue(source, base_url, details)
+            update_issue(KibbleBit, issue_doc)
+
+            labels = details["labels"]
+            change_people = []
+
+            if "owner" in details:
+                change_people.append(details["owner"])
+            if "Module-Owner" in labels and "all" in labels["Module-Owner"]:
+                change_people.extend(labels["Module-Owner"]["all"])
+            if "Code-Review" in labels and "all" in labels["Code-Review"]:
+                change_people.extend(labels["Code-Review"]["all"])
+            if "Verified" in labels and "all" in labels["Verified"]:
+                change_people.extend(labels["Verified"]["all"])
+
+            print(change["change_id"] + " -> " + str(len(change_people)) + " people.")
+
+            for person in change_people:
+                if "email" in person and person["email"] not in people:
+                    people[person["email"]] = person
+                    update_person(KibbleBit, make_person(source, person))
+
+        except requests.HTTPError as e:
+            print(e)
+
+    source["steps"]["issues"] = {
+        "time": time.time(),
+        "status": "Done analyzing tickets!",
+        "running": False,
+        "good": True,
+    }
+    KibbleBit.updateSource(source)

--- a/kibble/scanners/scanners/git-census.py
+++ b/kibble/scanners/scanners/git-census.py
@@ -1,0 +1,328 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import os
+import re
+import subprocess
+import time
+import tempfile
+import hashlib
+import email.utils
+import datetime, time
+
+title = "Census Scanner for Git"
+version = "0.1.0"
+
+
+def accepts(source):
+    """ Do we accept this source?? """
+    if source["type"] == "git":
+        return True
+    # There are cases where we have a github repo, but don't wanna annalyze the code, just issues
+    if source["type"] == "github" and source.get("issuesonly", False) == False:
+        return True
+    return False
+
+
+def scan(KibbleBit, source):
+    """ Conduct a census scan """
+    people = {}
+    idseries = {}
+    lcseries = {}
+    alcseries = {}
+    ctseries = {}
+    atseries = {}
+
+    rid = source["sourceID"]
+    url = source["sourceURL"]
+    rootpath = "%s/%s/git" % (
+        KibbleBit.config["scanner"]["scratchdir"],
+        source["organisation"],
+    )
+    gpath = os.path.join(rootpath, rid)
+
+    if "steps" in source and source["steps"]["sync"]["good"] and os.path.exists(gpath):
+        source["steps"]["census"] = {
+            "time": time.time(),
+            "status": "Census count started at "
+            + time.strftime("%a, %d %b %Y %H:%M:%S +0000", time.gmtime()),
+            "running": True,
+            "good": True,
+        }
+        KibbleBit.updateSource(source)
+        gname = rid
+        inp = ""
+        modificationDates = {}
+        # Did we do a census before?
+        if "census" in source and source["census"] > 0:
+            # Go back 2 months, meh...
+            ts = source["census"] - (62 * 86400)
+            pd = time.gmtime(ts)
+            date = time.strftime("%Y-%b-%d 0:00", pd)
+            inp = subprocess.check_output(
+                'git --git-dir %s/.git log --after="%s" --all "--pretty=format:::%%H|%%ce|%%cn|%%ae|%%an|%%ct" --numstat'
+                % (gpath, date),
+                shell=True,
+            )
+        else:
+            inp = subprocess.check_output(
+                'git --git-dir %s/.git log --all "--pretty=format:::%%H|%%ce|%%cn|%%ae|%%an|%%ct" --numstat'
+                % gpath,
+                shell=True,
+            )
+        tmp = tempfile.NamedTemporaryFile(mode="w+b", buffering=1, delete=False)
+        tmp.write(inp)
+        tmp.flush()
+        tmp.close()
+        with open(tmp.name, mode="r", encoding="utf-8", errors="replace") as f:
+            inp = f.read()
+            f.close()
+        os.unlink(tmp.name)
+        edone = 0
+        KibbleBit.pprint("Parsing log for %s (%s)..." % (rid, url))
+        for m in re.finditer(
+            u":([a-f0-9]+)\|([^\r\n|]+)\|([^\r\n|]+)\|([^\r\n|]+)\|([^\r\n|]+)\|([\d+]+)\r?\n([^:]+?):",
+            inp,
+            flags=re.MULTILINE,
+        ):
+            if m:
+                ch = m.group(1)
+                ce = m.group(2)
+                cn = m.group(3)
+                ae = m.group(4)
+                an = m.group(5)
+                ct = int(m.group(6))
+                diff = m.group(7)
+                insert = 0
+                delete = 0
+                files_touched = set()
+                # Diffs
+                for l in re.finditer(
+                    u"(\d+)[ \t]+(\d+)[ \t]+([^\r\n]+)", diff, flags=re.MULTILINE
+                ):
+                    insert += int(l.group(1))
+                    delete += int(l.group(2))
+                    filename = l.group(3)
+                    if filename:
+                        files_touched.update([filename])
+                    if (
+                        filename
+                        and len(filename) > 0
+                        and (
+                            not filename in modificationDates
+                            or modificationDates[filename]["timestamp"] < ct
+                        )
+                    ):
+                        modificationDates[filename] = {
+                            "hash": ch,
+                            "filename": filename,
+                            "timestamp": ct,
+                            "created": ct
+                            if (
+                                not filename in modificationDates
+                                or not "created" in modificationDates[filename]
+                                or modificationDates[filename]["created"] > ct
+                            )
+                            else modificationDates[filename]["created"],
+                            "author_email": ae,
+                            "committer_email": ce,
+                        }
+                    if insert > 100000000:
+                        insert = 0
+                    if delete > 100000000:
+                        delete = 0
+                    if delete > 1000000 or insert > 1000000:
+                        KibbleBit.pprint(
+                            "gigantic diff for %s (%s), ignoring"
+                            % (gpath, source["sourceURL"])
+                        )
+                        pass
+                if not gname in idseries:
+                    idseries[gname] = {}
+                if not gname in lcseries:
+                    lcseries[gname] = {}
+                if not gname in alcseries:
+                    alcseries[gname] = {}
+                if not gname in ctseries:
+                    ctseries[gname] = {}
+                if not gname in atseries:
+                    atseries[gname] = {}
+                ts = ct - (ct % 86400)
+                if not ts in idseries[gname]:
+                    idseries[gname][ts] = [0, 0]
+
+                idseries[gname][ts][0] += insert
+                idseries[gname][ts][1] += delete
+
+                if not ts in lcseries[gname]:
+                    lcseries[gname][ts] = {}
+                if not ts in alcseries[gname]:
+                    alcseries[gname][ts] = {}
+                if not ce in lcseries[gname][ts]:
+                    lcseries[gname][ts][ce] = [0, 0]
+                lcseries[gname][ts][ce][0] = lcseries[gname][ts][ce][0] + insert
+                lcseries[gname][ts][ce][1] = lcseries[gname][ts][ce][0] + delete
+
+                if not ae in alcseries[gname][ts]:
+                    alcseries[gname][ts][ae] = [0, 0]
+                alcseries[gname][ts][ae][0] = alcseries[gname][ts][ae][0] + insert
+                alcseries[gname][ts][ae][1] = alcseries[gname][ts][ae][0] + delete
+
+                if not ts in ctseries[gname]:
+                    ctseries[gname][ts] = {}
+                if not ts in atseries[gname]:
+                    atseries[gname][ts] = {}
+
+                if not ce in ctseries[gname][ts]:
+                    ctseries[gname][ts][ce] = 0
+                ctseries[gname][ts][ce] += 1
+
+                if not ae in atseries[gname][ts]:
+                    atseries[gname][ts][ae] = 0
+                atseries[gname][ts][ae] += 1
+
+                # Committer
+                if not ce in people or len(people[ce]["name"]) < len(cn):
+                    people[ce] = people[ce] if ce in people else {"projects": [gname]}
+                    people[ce]["name"] = cn
+                    if not gname in people[ce]["projects"]:
+                        people[ce]["projects"].append(gname)
+
+                # Author
+                if not ae in people or len(people[ae]["name"]) < len(an):
+                    people[ae] = people[ae] if ae in people else {"projects": [gname]}
+                    people[ae]["name"] = an
+                    if not gname in people[ae]["projects"]:
+                        people[ae]["projects"].append(gname)
+
+                # Make a list of changed files, max 1024
+                filelist = list(files_touched)
+                filelist = filelist[:1023]
+
+                # ES commit documents
+                tsd = ts - (ts % 86400)
+                js = {
+                    "id": rid + "/" + ch,
+                    "sourceID": rid,
+                    "sourceURL": source["sourceURL"],
+                    "organisation": source["organisation"],
+                    "ts": ct,
+                    "tsday": tsd,
+                    "date": time.strftime("%Y/%m/%d %H:%M:%S", time.gmtime(ct)),
+                    "committer_name": cn,
+                    "committer_email": ce,
+                    "author_name": an,
+                    "author_email": ae,
+                    "insertions": insert,
+                    "deletions": delete,
+                    "vcs": "git",
+                    "files_changed": filelist,
+                }
+                jsx = {
+                    "id": ch,
+                    "organisation": source["organisation"],
+                    "sourceID": source[
+                        "sourceID"
+                    ],  # Only ever the last source with this
+                    "ts": ct,
+                    "tsday": tsd,
+                    "date": time.strftime("%Y/%m/%d %H:%M:%S", time.gmtime(ct)),
+                    "committer_name": cn,
+                    "committer_email": ce,
+                    "author_name": an,
+                    "author_email": ae,
+                    "insertions": insert,
+                    "deletions": delete,
+                    "repository": rid,  # This will always ever only be the last repo that had it!
+                    "vcs": "git",
+                    "files_changed": filelist,
+                }
+                KibbleBit.append(
+                    "person",
+                    {
+                        "upsert": True,
+                        "name": cn,
+                        "email": ce,
+                        "address": ce,
+                        "organisation": source["organisation"],
+                        "id": hashlib.sha1(
+                            ("%s%s" % (source["organisation"], ce)).encode(
+                                "ascii", errors="replace"
+                            )
+                        ).hexdigest(),
+                    },
+                )
+                KibbleBit.append(
+                    "person",
+                    {
+                        "upsert": True,
+                        "name": an,
+                        "email": ae,
+                        "address": ae,
+                        "organisation": source["organisation"],
+                        "id": hashlib.sha1(
+                            ("%s%s" % (source["organisation"], ae)).encode(
+                                "ascii", errors="replace"
+                            )
+                        ).hexdigest(),
+                    },
+                )
+                KibbleBit.append("code_commit", js)
+                KibbleBit.append("code_commit_unique", jsx)
+
+        if True:  # Do file changes?? Might wanna make this optional
+            KibbleBit.pprint("Scanning file changes for %s" % source["sourceURL"])
+            for filename in modificationDates:
+                fid = hashlib.sha1(
+                    ("%s/%s" % (source["sourceID"], filename)).encode(
+                        "ascii", errors="replace"
+                    )
+                ).hexdigest()
+                jsfe = {
+                    "upsert": True,
+                    "id": fid,
+                    "organisation": source["organisation"],
+                    "sourceID": source["sourceID"],
+                    "ts": modificationDates[filename]["timestamp"],
+                    "date": time.strftime(
+                        "%Y/%m/%d %H:%M:%S",
+                        time.gmtime(modificationDates[filename]["timestamp"]),
+                    ),
+                    "committer_email": modificationDates[filename]["committer_email"],
+                    "author_email": modificationDates[filename]["author_email"],
+                    "hash": modificationDates[filename]["hash"],
+                    "created": modificationDates[filename]["created"],
+                    "createdDate": time.strftime(
+                        "%Y/%m/%d %H:%M:%S",
+                        time.gmtime(modificationDates[filename]["created"]),
+                    ),
+                }
+                found = KibbleBit.exists("file_history", fid)
+                if found:
+                    del jsfe["created"]
+                    del jsfe["createdDate"]
+                KibbleBit.append("file_history", jsfe)
+
+        source["steps"]["census"] = {
+            "time": time.time(),
+            "status": "Census count completed at "
+            + time.strftime("%a, %d %b %Y %H:%M:%S +0000", time.gmtime()),
+            "running": False,
+            "good": True,
+        }
+        source["census"] = time.time()
+        KibbleBit.updateSource(source)

--- a/kibble/scanners/scanners/git-evolution.py
+++ b/kibble/scanners/scanners/git-evolution.py
@@ -1,0 +1,259 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+""" Git Evolution scanner """
+import os
+import subprocess
+import time
+import calendar
+import datetime
+import hashlib
+
+from kibble.scanners.utils import sloc
+
+title = "Git Evolution Scanner"
+version = "0.1.0"
+
+
+def accepts(source):
+    """ Do we accept this source? """
+    if source["type"] == "git":
+        return True
+    # There are cases where we have a github repo, but don't wanna annalyze the code, just issues
+    if source["type"] == "github" and source.get("issuesonly", False) == False:
+        return True
+    return False
+
+
+def get_first_ref(gpath):
+    try:
+        return subprocess.check_output(
+            "cd %s && git log `git rev-list --max-parents=0 HEAD` --pretty=format:%%ct"
+            % gpath,
+            shell=True,
+        )
+    except:
+        print("Could not get first ref, exiting!")
+        return None
+
+
+def acquire(KibbleBit, source):
+    source["steps"]["evolution"] = {
+        "time": time.time(),
+        "status": "Evolution scan started at "
+        + time.strftime("%a, %d %b %Y %H:%M:%S +0000", time.gmtime()),
+        "running": True,
+        "good": True,
+    }
+    KibbleBit.updateSource(source)
+
+
+def release(KibbleBit, source, status, exception=None, good=False):
+    source["steps"]["evolution"] = {
+        "time": time.time(),
+        "status": status,
+        "running": False,
+        "good": good,
+    }
+
+    if exception:
+        source["steps"]["evolution"].update({"exception": exception})
+    KibbleBit.updateSource(source)
+
+
+def check_branch(gpath, date, branch):
+    try:
+        subprocess.check_call(
+            'cd %s && git rev-list -n 1 --before="%s" %s' % (gpath, date, branch),
+            shell=True,
+        )
+        return True
+    except:
+        return False
+
+
+def checkout(gpath, date, branch):
+    # print("Ready to cloc...checking out %s " % date)
+    try:
+        ref = (
+            subprocess.check_output(
+                'cd %s && git rev-list -n 1 --before="%s" "%s"' % (gpath, date, branch),
+                shell=True,
+                stderr=subprocess.STDOUT,
+            )
+            .decode("ascii", "replace")
+            .strip()
+        )
+        subprocess.check_output(
+            "cd %s && git checkout %s -- " % (gpath, ref),
+            shell=True,
+            stderr=subprocess.STDOUT,
+        )
+    except subprocess.CalledProcessError as err:
+        print(err.output)
+
+
+def find_branch(date, gpath):
+    try:
+        os.chdir(gpath)
+        subprocess.check_call(
+            'cd %s && git rev-list -n 1 --before="%s" master' % (gpath, date),
+            shell=True,
+            stderr=subprocess.DEVNULL,
+        )
+        return "master"
+    except:
+        os.chdir(gpath)
+        branch = ""
+        try:
+            return (
+                subprocess.check_output(
+                    "cd %s && git rev-parse --abbrev-ref HEAD" % gpath,
+                    shell=True,
+                    stderr=subprocess.DEVNULL,
+                )
+                .decode("ascii", "replace")
+                .strip()
+                .strip("* ")
+            )
+        except:
+            # print("meh! no branch")
+            return None
+
+
+def scan(KibbleBit, source):
+
+    rid = source["sourceID"]
+    url = source["sourceURL"]
+    rootpath = "%s/%s/git" % (
+        KibbleBit.config["scanner"]["scratchdir"],
+        source["organisation"],
+    )
+    gpath = os.path.join(rootpath, rid)
+
+    gname = source["sourceID"]
+    KibbleBit.pprint("Doing evolution scan of %s" % gname)
+
+    inp = get_first_ref(gpath)
+    if inp:
+        ts = int(inp.split()[0])
+        ts = ts - (ts % 86400)
+        date = time.strftime("%Y-%b-%d 0:00", time.gmtime(ts))
+
+        # print("Starting from %s" % date)
+        now = time.time()
+
+        rid = source["sourceID"]
+        url = source["sourceURL"]
+        rootpath = "%s/%s/git" % (
+            KibbleBit.config["scanner"]["scratchdir"],
+            source["organisation"],
+        )
+        gpath = os.path.join(rootpath, rid)
+
+        if source["steps"]["sync"]["good"] and os.path.exists(gpath):
+            acquire(KibbleBit, source)
+            branch = find_branch(date, gpath)
+
+            if not branch:
+                release(
+                    source,
+                    "Could not do evolutionary scan of code",
+                    "No default branch was found in this repository",
+                )
+                return
+
+            branch_exists = check_branch(gpath, date, branch)
+
+            if not branch_exists:
+                KibbleBit.pprint("Not trunk either (bad repo?), skipping")
+                release(
+                    source,
+                    "Could not do evolutionary scan of code",
+                    "No default branch was found in this repository",
+                )
+                return
+
+            try:
+
+                d = time.gmtime(now)
+                year = d[0]
+                quarter = d[1] - (d[1] % 3)
+                if quarter <= 0:
+                    quarter += 12
+                    year -= 1
+                while now > ts:
+                    pd = (
+                        datetime.datetime(year, quarter, 1)
+                        .replace(tzinfo=datetime.timezone.utc)
+                        .timetuple()
+                    )
+                    date = time.strftime("%Y-%b-%d 0:00", pd)
+                    unix = calendar.timegm(pd)
+
+                    # Skip the dates we've already processed
+                    dhash = hashlib.sha224(
+                        (source["sourceID"] + date).encode("ascii", "replace")
+                    ).hexdigest()
+                    found = KibbleBit.exists("evolution", dhash)
+                    if not found:
+                        checkout(gpath, date, branch)
+                        KibbleBit.pprint(
+                            "Running cloc on %s (%s) at %s"
+                            % (gname, source["sourceURL"], date)
+                        )
+                        languages, codecount, comment, blank, years, cost = sloc.count(
+                            gpath
+                        )
+                        js = {
+                            "time": unix,
+                            "sourceID": source["sourceID"],
+                            "sourceURL": source["sourceURL"],
+                            "organisation": source["organisation"],
+                            "loc": codecount,
+                            "comments": comment,
+                            "blank": blank,
+                            "years": years,
+                            "cost": cost,
+                            "languages": languages,
+                        }
+                        KibbleBit.index("evolution", dhash, js)
+                    quarter -= 3
+                    if quarter <= 0:
+                        quarter += 12
+                        year -= 1
+
+                    # decrease month by 3
+                    now = time.mktime(datetime.date(year, quarter, 1).timetuple())
+            except Exception as e:
+                KibbleBit.pprint(e)
+                release(
+                    KibbleBit,
+                    source,
+                    "Evolution scan failed at "
+                    + time.strftime("%a, %d %b %Y %H:%M:%S +0000", time.gmtime()),
+                    str(e),
+                )
+                return
+
+            release(
+                KibbleBit,
+                source,
+                "Evolution scan completed at "
+                + time.strftime("%a, %d %b %Y %H:%M:%S +0000", time.gmtime()),
+                good=True,
+            )

--- a/kibble/scanners/scanners/git-sloc.py
+++ b/kibble/scanners/scanners/git-sloc.py
@@ -1,0 +1,87 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import os
+import subprocess
+import time
+
+from kibble.scanners.utils import sloc, git
+
+""" Source Lines of Code counter for Git """
+
+title = "SloC Counter for Git"
+version = "0.1.0"
+
+
+def accepts(source):
+    """ Do we accept this source? """
+    if source["type"] == "git":
+        return True
+    # There are cases where we have a github repo, but don't wanna annalyze the code, just issues
+    if source["type"] == "github" and source.get("issuesonly", False) == False:
+        return True
+    return False
+
+
+def scan(KibbleBit, source):
+
+    rid = source["sourceID"]
+    url = source["sourceURL"]
+    rootpath = "%s/%s/git" % (
+        KibbleBit.config["scanner"]["scratchdir"],
+        source["organisation"],
+    )
+    gpath = os.path.join(rootpath, rid)
+
+    if source["steps"]["sync"]["good"] and os.path.exists(gpath):
+        source["steps"]["count"] = {
+            "time": time.time(),
+            "status": "SLoC count started at "
+            + time.strftime("%a, %d %b %Y %H:%M:%S +0000", time.gmtime()),
+            "running": True,
+            "good": True,
+        }
+        KibbleBit.updateSource(source)
+
+        try:
+            branch = git.defaultBranch(source, gpath)
+            subprocess.call("cd %s && git checkout %s" % (gpath, branch), shell=True)
+        except:
+            KibbleBit.pprint("SLoC counter failed to find main branch for %s!!" % url)
+            return False
+
+        KibbleBit.pprint("Running SLoC count for %s" % url)
+        languages, codecount, comment, blank, years, cost = sloc.count(gpath)
+
+        sloc_ = {
+            "sourceID": source["sourceID"],
+            "loc": codecount,
+            "comments": comment,
+            "blanks": blank,
+            "years": years,
+            "cost": cost,
+            "languages": languages,
+        }
+        source["sloc"] = sloc_
+        source["steps"]["count"] = {
+            "time": time.time(),
+            "status": "SLoC count completed at "
+            + time.strftime("%a, %d %b %Y %H:%M:%S +0000", time.gmtime()),
+            "running": False,
+            "good": True,
+        }
+        KibbleBit.updateSource(source)

--- a/kibble/scanners/scanners/git-sync.py
+++ b/kibble/scanners/scanners/git-sync.py
@@ -1,0 +1,174 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import os
+import subprocess
+import time
+
+from kibble.scanners.utils import git
+
+title = "Sync plugin for Git repositories"
+version = "0.1.2"
+
+
+def accepts(source):
+    """ Do we accept this source? """
+    if source["type"] == "git":
+        return True
+    # There are cases where we have a github repo, but don't wanna annalyze the code, just issues
+    if source["type"] == "github" and source.get("issuesonly", False) == False:
+        return True
+    return False
+
+
+def scan(KibbleBit, source):
+
+    # Get some vars, construct a data path for the repo
+    path = source["sourceID"]
+    url = source["sourceURL"]
+    rootpath = "%s/%s/git" % (
+        KibbleBit.config["scanner"]["scratchdir"],
+        source["organisation"],
+    )
+
+    # If the root path does not exist, try to make it recursively.
+    if not os.path.exists(rootpath):
+        try:
+            os.makedirs(rootpath, exist_ok=True)
+            print("Created root path %s" % rootpath)
+        except Exception as err:
+            source["steps"]["sync"] = {
+                "time": time.time(),
+                "status": "Could not create root scratch dir - permision denied?",
+                "running": False,
+                "good": False,
+            }
+            KibbleBit.updateSource(source)
+            return
+
+    # This is were the repo should be cloned
+    datapath = os.path.join(rootpath, path)
+
+    KibbleBit.pprint("Checking out %s as %s" % (url, path))
+
+    try:
+        source["steps"]["sync"] = {
+            "time": time.time(),
+            "status": "Fetching code data from source location...",
+            "running": True,
+            "good": True,
+        }
+        KibbleBit.updateSource(source)
+
+        # If we already checked this out earlier, just sync it.
+        if os.path.exists(datapath):
+            KibbleBit.pprint("Repo %s exists, fetching changes..." % datapath)
+
+            # Do we have a default branch here?
+            branch = git.defaultBranch(source, datapath, KibbleBit)
+            if len(branch) == 0:
+                source["default_branch"] = branch
+                source["steps"]["sync"] = {
+                    "time": time.time(),
+                    "status": "Could not sync with source",
+                    "exception": "No default branch was found in this repository",
+                    "running": False,
+                    "good": False,
+                }
+                KibbleBit.updateSource(source)
+                KibbleBit.pprint(
+                    "No default branch found for %s (%s)"
+                    % (source["sourceID"], source["sourceURL"])
+                )
+                return
+
+            KibbleBit.pprint("Using branch %s" % branch)
+            # Try twice checking out the main branch and fetching changes.
+            # Sometimes we need to clean up after older scanners, which is
+            # why we try twice. If first attempt fails, clean up and try again.
+            for n in range(0, 2):
+                try:
+                    subprocess.check_output(
+                        "GIT_TERMINAL_PROMPT=0 cd %s && git checkout %s && git fetch --all && git merge -X theirs --no-edit"
+                        % (datapath, branch),
+                        shell=True,
+                        stderr=subprocess.STDOUT,
+                    )
+                    break
+                except subprocess.CalledProcessError as err:
+                    e = str(err.output).lower()
+                    # We're interested in merge conflicts, which we can resolve through trickery.
+                    if n > 0 or not (
+                        "resolve" in e or "merge" in e or "overwritten" in e
+                    ):
+                        # This isn't a merge conflict, pass it to outer func
+                        raise err
+                    else:
+                        # Switch to first commit
+                        fcommit = subprocess.check_output(
+                            "cd %s && git rev-list --max-parents=0 --abbrev-commit HEAD"
+                            % datapath,
+                            shell=True,
+                            stderr=subprocess.STDOUT,
+                        )
+                        fcommit = fcommit.decode("ascii").strip()
+                        subprocess.check_call(
+                            "cd %s && git reset --hard %s" % (datapath, fcommit),
+                            shell=True,
+                            stderr=subprocess.STDOUT,
+                        )
+                        try:
+                            subprocess.check_call(
+                                "cd %s && git clean -xfd" % datpath,
+                                shell=True,
+                                stderr=subprocess.STDOUT,
+                            )
+                        except:
+                            pass
+        # This is a new repo, clone it!
+        else:
+            KibbleBit.pprint("%s is new, cloning...!" % datapath)
+            subprocess.check_output(
+                "GIT_TERMINAL_PROMPT=0 cd %s && git clone %s %s"
+                % (rootpath, url, path),
+                shell=True,
+                stderr=subprocess.STDOUT,
+            )
+
+    except subprocess.CalledProcessError as err:
+        KibbleBit.pprint("Repository sync failed (no master?)")
+        KibbleBit.pprint(str(err.output))
+        source["steps"]["sync"] = {
+            "time": time.time(),
+            "status": "Sync failed at "
+            + time.strftime("%a, %d %b %Y %H:%M:%S +0000", time.gmtime()),
+            "running": False,
+            "good": False,
+            "exception": str(err.output),
+        }
+        KibbleBit.updateSource(source)
+        return
+
+    # All good, yay!
+    source["steps"]["sync"] = {
+        "time": time.time(),
+        "status": "Source code fetched successfully at "
+        + time.strftime("%a, %d %b %Y %H:%M:%S +0000", time.gmtime()),
+        "running": False,
+        "good": True,
+    }
+    KibbleBit.updateSource(source)

--- a/kibble/scanners/scanners/github-issues.py
+++ b/kibble/scanners/scanners/github-issues.py
@@ -1,0 +1,245 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import re
+import hashlib
+from dateutil import parser
+import time
+import requests
+
+from kibble.scanners.utils import github
+
+title = "Scanner for GitHub Issues"
+version = "0.1.0"
+
+
+def accepts(source):
+    """ Return true if this is a github repo """
+    if source["type"] == "github":
+        return True
+    if source["type"] == "git" and re.match(
+        r"https://(?:www\.)?github.com/", source["sourceURL"]
+    ):
+        return True
+    return False
+
+
+def format_date(d, epoch=False):
+    if not d:
+        return
+    parsed = parser.parse(d)
+
+    if epoch:
+        return time.mktime(parsed.timetuple())
+
+    return time.strftime("%Y/%m/%d %H:%M:%S", parsed.timetuple())
+
+
+def make_hash(source, issue):
+    return hashlib.sha224(
+        (
+            "%s-%s-%s" % (source["organisation"], source["sourceID"], str(issue["id"]))
+        ).encode("ascii", errors="replace")
+    ).hexdigest()
+
+
+def make_issue(source, issue, people):
+
+    key = str(issue["number"])
+    dhash = make_hash(source, issue)
+
+    closed_date = issue.get("closed_at", None)
+
+    owner_email = people[issue["user"]["login"]]["email"]
+
+    issue_closer = owner_email
+    if "closed_by" in issue:
+        issue_closer = people[issue["closed_by"]["login"]]
+    # Is this an issue ro a pull request?
+    itype = "issue"
+    if "pull_request" in issue:
+        itype = "pullrequest"
+    labels = []
+    for l in issue.get("labels", []):
+        labels.append(l["name"])
+    return {
+        "id": dhash,
+        "key": key,
+        "issuetype": itype,
+        "organisation": source["organisation"],
+        "sourceID": source["sourceID"],
+        "url": issue["html_url"],
+        "status": issue["state"],
+        "labels": labels,
+        "created": format_date(issue["created_at"], epoch=True),
+        "closed": format_date(closed_date, epoch=True),
+        "issueCloser": issue_closer,
+        "createdDate": format_date(issue["created_at"]),
+        "closedDate": format_date(closed_date),
+        "changeDate": format_date(closed_date if closed_date else issue["updated_at"]),
+        "assignee": owner_email,
+        "issueCreator": owner_email,
+        "comments": issue["comments"],
+        "title": issue["title"],
+    }
+
+
+def make_person(source, issue, raw_person):
+    email = raw_person["email"]
+    if not email:
+        email = "%s@invalid.github.com" % issue["user"]["login"]
+
+    name = raw_person["name"]
+    if not name:
+        name = raw_person["login"]
+
+    id = hashlib.sha1(
+        ("%s%s" % (source["organisation"], email)).encode("ascii", errors="replace")
+    ).hexdigest()
+
+    return {
+        "email": email,
+        "id": id,
+        "organisation": source["organisation"],
+        "name": name,
+    }
+
+
+def status_changed(stored_issue, issue):
+    return stored_issue["status"] != issue["status"]
+
+
+def update_issue(KibbleBit, issue):
+    KibbleBit.append("issue", issue)
+
+
+def update_person(KibbleBit, person):
+    person["upsert"] = True
+    KibbleBit.append("person", person)
+
+
+def scan(KibbleBit, source, firstAttempt=True):
+    auth = None
+    people = {}
+    if "creds" in source:
+        KibbleBit.pprint("Using auth for repo %s" % source["sourceURL"])
+        creds = source["creds"]
+        if creds and "username" in creds:
+            auth = (creds["username"], creds["password"])
+    TL = github.get_tokens_left(auth=auth)
+    KibbleBit.pprint("Scanning for GitHub issues (%u tokens left on GitHub)" % TL)
+    # Have we scanned before? If so, only do a 3 month scan here.
+    doneBefore = False
+    if source.get("steps") and source["steps"].get("issues"):
+        doneBefore = True
+    source["steps"]["issues"] = {
+        "time": time.time(),
+        "status": "Issue scan started at "
+        + time.strftime("%a, %d %b %Y %H:%M:%S +0000", time.gmtime()),
+        "running": True,
+        "good": True,
+    }
+    KibbleBit.updateSource(source)
+    try:
+        if doneBefore:
+            since = time.strftime(
+                "%Y-%m-%dT%H:%M:%SZ", time.gmtime(time.time() - (3 * 30 * 86400))
+            )
+            KibbleBit.pprint("Fetching changes since %s" % since)
+            issues = github.get_all(
+                source,
+                github.issues,
+                params={"filter": "all", "state": "all", "since": since},
+                auth=auth,
+            )
+        else:
+            issues = github.get_all(
+                source,
+                github.issues,
+                params={"filter": "all", "state": "all"},
+                auth=auth,
+            )
+        KibbleBit.pprint(
+            "Fetched %s issues for %s" % (str(len(issues)), source["sourceURL"])
+        )
+
+        for issue in issues:
+
+            if not issue["user"]["login"] in people:
+                person = make_person(
+                    source, issue, github.user(issue["user"]["url"], auth=auth)
+                )
+                people[issue["user"]["login"]] = person
+                update_person(KibbleBit, person)
+
+            if "closed_by" in issue and not issue["closed_by"]["login"] in people:
+                closer = make_person(
+                    source, issue, github.user(issue["closed_by"]["url"], auth=auth)
+                )
+                people[issue["closed_by"]["login"]] = closer
+                update_person(KibbleBit, closer)
+
+            doc = make_issue(source, issue, people)
+            dhash = doc["id"]
+            stored_change = None
+            if KibbleBit.exists("issue", dhash):
+                es_doc = KibbleBit.get("issue", dhash)
+                if not status_changed(es_doc, doc):
+                    # KibbleBit.pprint("change %s seen already and status unchanged. Skipping." % issue['id'])
+                    continue
+
+            update_issue(KibbleBit, doc)
+
+        source["steps"]["issues"] = {
+            "time": time.time(),
+            "status": "Issue scan completed at "
+            + time.strftime("%a, %d %b %Y %H:%M:%S +0000", time.gmtime()),
+            "running": False,
+            "good": True,
+        }
+        KibbleBit.updateSource(source)
+
+    except requests.HTTPError as e:
+        # If we errored out because of rate limiting, retry later, otherwise bail
+        if firstAttempt:
+            sleeps = 0
+            if github.get_tokens_left(auth=auth) < 10:
+                KibbleBit.pprint("Hit rate limits, trying to sleep it off!")
+                while github.get_tokens_left(auth=auth) < 10:
+                    sleeps += 1
+                    if sleeps > 24:
+                        KibbleBit.pprint(
+                            "Slept for too long without finding a reset rate limit, giving up!"
+                        )
+                        break
+                    time.sleep(300)  # Sleep 5 min, then check again..
+                # If we have tokens, try one more time...
+                if github.get_tokens_left(auth=auth) > 10:
+                    scan(KibbleBit, source, False)  # If this one fails, bail completely
+                    return
+
+        KibbleBit.pprint("HTTP Error, rate limit exceeded?")
+        source["steps"]["issues"] = {
+            "time": time.time(),
+            "status": "Issue scan failed at "
+            + time.strftime("%a, %d %b %Y %H:%M:%S +0000", time.gmtime())
+            + ": "
+            + e.response.text,
+            "running": False,
+            "good": False,
+        }
+        KibbleBit.updateSource(source)

--- a/kibble/scanners/scanners/github-stats.py
+++ b/kibble/scanners/scanners/github-stats.py
@@ -1,0 +1,139 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import hashlib
+import re
+import time
+
+from kibble.scanners.utils import github
+
+title = "Traffic statistics plugin for GitHub repositories"
+version = "0.1.0"
+
+
+def accepts(source):
+    """ Do we accept this source? """
+    if source["type"] == "github":
+        return True
+    return False
+
+
+def getTime(string):
+    """ Convert GitHub timestamp to epoch """
+    return time.mktime(
+        time.strptime(re.sub(r"Z", "", str(string)), "%Y-%m-%dT%H:%M:%S")
+    )
+
+
+def scan(KibbleBit, source):
+
+    # Get some vars, construct a data path for the repo
+    path = source["sourceID"]
+    url = source["sourceURL"]
+
+    auth = None
+    people = {}
+    if "creds" in source:
+        KibbleBit.pprint("Using auth for repo %s" % source["sourceURL"])
+        creds = source["creds"]
+        if creds and "username" in creds:
+            auth = (creds["username"], creds["password"])
+    else:
+        KibbleBit.pprint(
+            "GitHub stats requires auth, none provided. Ignoring this repo."
+        )
+        return
+    try:
+        source["steps"]["stats"] = {
+            "time": time.time(),
+            "status": "Fetching statistics from source location...",
+            "running": True,
+            "good": True,
+        }
+        KibbleBit.updateSource(source)
+
+        # Get views
+        views = github.views(url, auth)
+        if "views" in views:
+            for el in views["views"]:
+                ts = getTime(el["timestamp"])
+                shash = hashlib.sha224(
+                    (
+                        "%s-%s-%s-clones"
+                        % (source["organisation"], url, el["timestamp"])
+                    ).encode("ascii", errors="replace")
+                ).hexdigest()
+                bit = {
+                    "organisation": source["organisation"],
+                    "sourceURL": source["sourceURL"],
+                    "sourceID": source["sourceID"],
+                    "date": time.strftime("%Y/%m/%d %H:%M:%S", time.gmtime(ts)),
+                    "count": el["count"],
+                    "uniques": el["uniques"],
+                    "ghtype": "views",
+                    "id": shash,
+                }
+                KibbleBit.append("ghstats", bit)
+
+        # Get clones
+        clones = github.clones(url, auth)
+        if "clones" in clones:
+            for el in clones["clones"]:
+                ts = getTime(el["timestamp"])
+                shash = hashlib.sha224(
+                    (
+                        "%s-%s-%s-clones"
+                        % (source["organisation"], url, el["timestamp"])
+                    ).encode("ascii", errors="replace")
+                ).hexdigest()
+                bit = {
+                    "organisation": source["organisation"],
+                    "sourceURL": source["sourceURL"],
+                    "sourceID": source["sourceID"],
+                    "date": time.strftime("%Y/%m/%d %H:%M:%S", time.gmtime(ts)),
+                    "count": el["count"],
+                    "uniques": el["uniques"],
+                    "ghtype": "clones",
+                    "id": shash,
+                }
+                KibbleBit.append("ghstats", bit)
+
+        # Get referrers
+        refs = github.referrers(url, auth)
+        if refs:
+            for el in refs:
+                el["timestamp"] = time.strftime("%Y-%m-%dT%H:%M:%S", time.time())
+                ts = getTime(el["timestamp"])
+                shash = hashlib.sha224(
+                    (
+                        "%s-%s-%s-refs" % (source["organisation"], url, el["timestamp"])
+                    ).encode("ascii", errors="replace")
+                ).hexdigest()
+                bit = {
+                    "organisation": source["organisation"],
+                    "sourceURL": source["sourceURL"],
+                    "sourceID": source["sourceID"],
+                    "date": time.strftime("%Y/%m/%d %H:%M:%S", time.gmtime(ts)),
+                    "count": el["count"],
+                    "uniques": el["uniques"],
+                    "ghtype": "referrers",
+                    "id": shash,
+                }
+                KibbleBit.append("ghstats", bit)
+    except:
+        pass
+        # All done!

--- a/kibble/scanners/scanners/jenkins.py
+++ b/kibble/scanners/scanners/jenkins.py
@@ -1,0 +1,356 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import time
+import datetime
+import re
+import hashlib
+import threading
+import urllib.parse
+
+from kibble.scanners.utils import jsonapi
+
+"""
+This is the Kibble Jenkins scanner plugin.
+"""
+
+title = "Scanner for Jenkins CI"
+version = "0.1.0"
+
+
+def accepts(source):
+    """ Determines whether we want to handle this source """
+    if source["type"] == "jenkins":
+        return True
+    return False
+
+
+def scanJob(KibbleBit, source, job, creds):
+    """ Scans a single job for activity """
+    NOW = int(datetime.datetime.utcnow().timestamp())
+    jname = job["name"]
+    if job.get("folder"):
+        jname = job.get("folder") + "-" + job["name"]
+    dhash = hashlib.sha224(
+        ("%s-%s-%s" % (source["organisation"], source["sourceURL"], jname)).encode(
+            "ascii", errors="replace"
+        )
+    ).hexdigest()
+    found = True
+    doc = None
+    parseIt = False
+    found = KibbleBit.exists("cijob", dhash)
+
+    # Get $jenkins/job/$job-name/json...
+    jobURL = (
+        "%s/api/json?depth=2&tree=builds[number,status,timestamp,id,result,duration]"
+        % job["fullURL"]
+    )
+    KibbleBit.pprint(jobURL)
+    jobjson = jsonapi.get(jobURL, auth=creds)
+
+    # If valid JSON, ...
+    if jobjson:
+        for build in jobjson.get("builds", []):
+            buildhash = hashlib.sha224(
+                (
+                    "%s-%s-%s-%s"
+                    % (source["organisation"], source["sourceURL"], jname, build["id"])
+                ).encode("ascii", errors="replace")
+            ).hexdigest()
+            builddoc = None
+            try:
+                builddoc = KibbleBit.get("ci_build", buildhash)
+            except:
+                pass
+
+            # If this build already completed, no need to parse it again
+            if builddoc and builddoc.get("completed", False):
+                continue
+
+            KibbleBit.pprint(
+                "[%s-%s] This is new or pending, analyzing..." % (jname, build["id"])
+            )
+
+            completed = True if build["result"] else False
+
+            # Estimate time spent in queue
+            queuetime = 0
+            TS = int(build["timestamp"] / 1000)
+            if builddoc:
+                queuetime = builddoc.get("queuetime", 0)
+            if not completed:
+                queuetime = NOW - TS
+
+            # Get build status (success, failed, canceled etc)
+            status = "building"
+            if build["result"] in ["SUCCESS", "STABLE"]:
+                status = "success"
+            if build["result"] in ["FAILURE", "UNSTABLE"]:
+                status = "failed"
+            if build["result"] in ["ABORTED"]:
+                status = "aborted"
+
+            # Calc when the build finished (jenkins doesn't show this)
+            if completed:
+                FIN = int(build["timestamp"] + build["duration"]) / 1000
+            else:
+                FIN = 0
+
+            doc = {
+                # Build specific data
+                "id": buildhash,
+                "date": time.strftime("%Y/%m/%d %H:%M:%S", time.gmtime(FIN)),
+                "buildID": build["id"],
+                "completed": completed,
+                "duration": build["duration"],
+                "job": jname,
+                "jobURL": jobURL,
+                "status": status,
+                "started": int(build["timestamp"] / 1000),
+                "ci": "jenkins",
+                "queuetime": queuetime,
+                # Standard docs values
+                "sourceID": source["sourceID"],
+                "organisation": source["organisation"],
+                "upsert": True,
+            }
+            KibbleBit.append("ci_build", doc)
+        # Yay, it worked!
+        return True
+
+    # Boo, it failed!
+    KibbleBit.pprint("Fetching job data failed!")
+    return False
+
+
+class jenkinsThread(threading.Thread):
+    """ Generic thread class for scheduling multiple scans at once """
+
+    def __init__(self, block, KibbleBit, source, creds, jobs):
+        super(jenkinsThread, self).__init__()
+        self.block = block
+        self.KibbleBit = KibbleBit
+        self.creds = creds
+        self.source = source
+        self.jobs = jobs
+
+    def run(self):
+        badOnes = 0
+        while len(self.jobs) > 0 and badOnes <= 50:
+            self.block.acquire()
+            try:
+                job = self.jobs.pop(0)
+            except Exception as err:
+                self.block.release()
+                return
+            if not job:
+                self.block.release()
+                return
+            self.block.release()
+            jfolder = job.get("folder")
+            ssource = dict(self.source)
+            if jfolder:
+                ssource["sourceURL"] += "/job/" + jfolder
+            if not scanJob(self.KibbleBit, ssource, job, self.creds):
+                self.KibbleBit.pprint(
+                    "[%s] This borked, trying another one" % job["name"]
+                )
+                badOnes += 1
+                if badOnes > 100:
+                    self.KibbleBit.pprint("Too many errors, bailing!")
+                    self.source["steps"]["issues"] = {
+                        "time": time.time(),
+                        "status": "Too many errors while parsing at "
+                        + time.strftime("%Y/%m/%d %H:%M:%S", time.gmtime(time.time())),
+                        "running": False,
+                        "good": False,
+                    }
+                    self.KibbleBit.updateSource(self.source)
+                    return
+            else:
+                badOnes = 0
+
+
+def scan(KibbleBit, source):
+    # Simple URL check
+    jenkins = re.match(r"(https?://.+)", source["sourceURL"])
+    if jenkins:
+
+        source["steps"]["jenkins"] = {
+            "time": time.time(),
+            "status": "Parsing Jenkins job changes...",
+            "running": True,
+            "good": True,
+        }
+        KibbleBit.updateSource(source)
+
+        badOnes = 0
+        pendingJobs = []
+        KibbleBit.pprint("Parsing Jenkins activity at %s" % source["sourceURL"])
+        source["steps"]["issues"] = {
+            "time": time.time(),
+            "status": "Downloading changeset",
+            "running": True,
+            "good": True,
+        }
+        KibbleBit.updateSource(source)
+
+        # Jenkins may neeed credentials
+        creds = None
+        if (
+            source["creds"]
+            and "username" in source["creds"]
+            and source["creds"]["username"]
+            and len(source["creds"]["username"]) > 0
+        ):
+            creds = "%s:%s" % (source["creds"]["username"], source["creds"]["password"])
+
+        # Get the job list
+        sURL = source["sourceURL"]
+        KibbleBit.pprint("Getting job list...")
+        jobsjs = jsonapi.get(
+            "%s/api/json?tree=jobs[name,color]&depth=1" % sURL, auth=creds
+        )
+
+        # Get the current queue
+        KibbleBit.pprint("Getting job queue...")
+        queuejs = jsonapi.get("%s/queue/api/json?depth=1" % sURL, auth=creds)
+
+        # Save queue snapshot
+        NOW = int(datetime.datetime.utcnow().timestamp())
+        queuehash = hashlib.sha224(
+            (
+                "%s-%s-queue-%s"
+                % (source["organisation"], source["sourceURL"], int(time.time()))
+            ).encode("ascii", errors="replace")
+        ).hexdigest()
+
+        # Scan queue items
+        blocked = 0
+        stuck = 0
+        totalqueuetime = 0
+        items = queuejs.get("items", [])
+
+        for item in items:
+            if item["blocked"]:
+                blocked += 1
+            if item["stuck"]:
+                stuck += 1
+            if "inQueueSince" in item:
+                totalqueuetime += NOW - int(item["inQueueSince"] / 1000)
+
+        avgqueuetime = totalqueuetime / max(1, len(items))
+
+        # Count how many jobs are building, find any folders...
+        actual_jobs, building = get_all_jobs(
+            KibbleBit, source, jobsjs.get("jobs", []), creds
+        )
+
+        # Write up a queue doc
+        queuedoc = {
+            "id": queuehash,
+            "date": time.strftime("%Y/%m/%d %H:%M:%S", time.gmtime(NOW)),
+            "time": NOW,
+            "building": building,
+            "size": len(items),
+            "blocked": blocked,
+            "stuck": stuck,
+            "avgwait": avgqueuetime,
+            "ci": "jenkins",
+            # Standard docs values
+            "sourceID": source["sourceID"],
+            "organisation": source["organisation"],
+            "upsert": True,
+        }
+        KibbleBit.append("ci_queue", queuedoc)
+
+        pendingJobs = actual_jobs
+        KibbleBit.pprint("Found %u jobs in Jenkins" % len(pendingJobs))
+
+        threads = []
+        block = threading.Lock()
+        KibbleBit.pprint("Scanning jobs using 4 sub-threads")
+        for i in range(0, 4):
+            t = jenkinsThread(block, KibbleBit, source, creds, pendingJobs)
+            threads.append(t)
+            t.start()
+
+        for t in threads:
+            t.join()
+
+        # We're all done, yaay
+        KibbleBit.pprint("Done scanning %s" % source["sourceURL"])
+
+        source["steps"]["issues"] = {
+            "time": time.time(),
+            "status": "Jenkins successfully scanned at "
+            + time.strftime("%Y/%m/%d %H:%M:%S", time.gmtime(time.time())),
+            "running": False,
+            "good": True,
+        }
+        KibbleBit.updateSource(source)
+
+
+def get_all_jobs(KibbleBit, source, joblist, creds):
+    real_jobs = []
+    building = 0
+    for job in joblist:
+        # Is this a job folder?
+        jclass = job.get("_class")
+        if jclass in [
+            "jenkins.branch.OrganizationFolder",
+            "org.jenkinsci.plugins.workflow.multibranch.WorkflowMultiBranchProject",
+        ]:
+            KibbleBit.pprint("%s is a jobs folder, expanding..." % job["name"])
+            csURL = "%s/job/%s" % (
+                source["sourceURL"],
+                urllib.parse.quote(job["name"].replace("/", "%2F")),
+            )
+            try:
+                child_jobs = jsonapi.get(
+                    "%s/api/json?tree=jobs[name,color]&depth=1" % csURL, auth=creds
+                )
+                csource = dict(source)
+                csource["sourceURL"] = csURL
+                if not csource.get("folder"):
+                    csource["folder"] = job["name"]
+                else:
+                    csource["folder"] += "-" + job["name"]
+                cjobs, cbuilding = get_all_jobs(
+                    KibbleBit, csource, child_jobs.get("jobs", []), creds
+                )
+                building += cbuilding
+                for cjob in cjobs:
+                    real_jobs.append(cjob)
+            except:
+                KibbleBit.pprint("Couldn't get child jobs, bailing")
+                print("%s/api/json?tree=jobs[name,color]&depth=1" % csURL)
+        # Or standard job?
+        else:
+            # Is it building?
+            if "anime" in job.get(
+                "color", ""
+            ):  # a running job will have foo_anime as color
+                building += 1
+            job["fullURL"] = "%s/job/%s" % (
+                source["sourceURL"],
+                urllib.parse.quote(job["name"].replace("/", "%2F")),
+            )
+            job["folder"] = source.get("folder")
+            real_jobs.append(job)
+    return real_jobs, building

--- a/kibble/scanners/scanners/jira.py
+++ b/kibble/scanners/scanners/jira.py
@@ -1,0 +1,463 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import time
+import re
+import hashlib
+import threading
+import requests.exceptions
+
+from kibble.scanners.utils import jsonapi
+
+"""
+This is the Kibble JIRA scanner plugin.
+"""
+
+title = "Scanner for Atlassian JIRA"
+version = "0.1.0"
+
+
+def accepts(source):
+    """ Determines whether we want to handle this source """
+    if source["type"] == "jira":
+        return True
+    if source["type"] == "issuetracker":
+        jira = re.match(r"(https?://.+)/browse/([A-Z0-9]+)", url)
+        if jira:
+            return True
+    return False
+
+
+def getTime(string):
+    return time.mktime(
+        time.strptime(re.sub(r"\..*", "", str(string)), "%Y-%m-%dT%H:%M:%S")
+    )
+
+
+def assigned(js):
+    if "items" in js:
+        for item in js["items"]:
+            if item["field"] == "assignee":
+                return True
+    return False
+
+
+def wfi(js):
+    if "items" in js:
+        for item in js["items"]:
+            if item["field"] == "status" and item["toString"] == "Waiting for Infra":
+                return True
+    return False
+
+
+def wfu(js):
+    if "items" in js:
+        for item in js["items"]:
+            if item["field"] == "status" and item["toString"] == "Waiting for user":
+                return True
+    return False
+
+
+def moved(js):
+    if "items" in js:
+        for item in js["items"]:
+            if item["field"] == "Key" and item["toString"].find("INFRA-") != -1:
+                return True
+    return False
+
+
+def wasclosed(js):
+    if "changelog" in js:
+        cjs = js["changelog"]["histories"]
+        for citem in cjs:
+            if "items" in citem:
+                for item in citem["items"]:
+                    if item["field"] == "status" and (
+                        item["toString"].lower().find("closed") != -1
+                        or item["toString"].lower().find("resolved") != -1
+                    ):
+                        return (True, citem.get("author", {}))
+    else:
+        if "items" in js:
+            for item in js["items"]:
+                if item["field"] == "status" and (
+                    item["toString"].find("Closed") != -1
+                ):
+                    return (True, None)
+    return (False, None)
+
+
+def resolved(js):
+    if "items" in js:
+        for item in js["items"]:
+            if item["field"] == "resolution" and (
+                item["toString"] != "Pending Closed"
+                and item["toString"] != "Unresolved"
+            ):
+                return True
+    return False
+
+
+def pchange(js):
+    if "items" in js:
+        for item in js["items"]:
+            if item["field"] == "priority":
+                return True
+    return False
+
+
+def scanTicket(KibbleBit, key, u, source, creds, openTickets):
+    """ Scans a single ticket for activity and people """
+
+    dhash = hashlib.sha224(
+        ("%s-%s-%s" % (source["organisation"], source["sourceURL"], key)).encode(
+            "ascii", errors="replace"
+        )
+    ).hexdigest()
+    found = True
+    doc = None
+    parseIt = False
+
+    # the 'domain' var we try to figure out here is used
+    # for faking email addresses and keep them unique,
+    # in case JIRA has email visibility turned off.
+    domain = "jira"
+    m = re.search(r"https?://([^/]+)", u)
+    if m:
+        domain = m.group(1)
+
+    found = KibbleBit.exists("issue", dhash)
+    if not found:
+        KibbleBit.pprint("[%s] We've never seen this ticket before, parsing..." % key)
+        parseIt = True
+    else:
+        ticket = KibbleBit.get("issue", dhash)
+        if ticket["status"] == "closed" and key in openTickets:
+            KibbleBit.pprint("[%s] Ticket was reopened, reparsing" % key)
+            parseIt = True
+        elif ticket["status"] == "open" and not key in openTickets:
+            KibbleBit.pprint("[%s] Ticket was recently closed, parsing it" % key)
+            parseIt = True
+        else:
+            if (
+                ticket["issueCreator"] == "unknown@kibble"
+                or ticket["issueCloser"] == "unknown@kibble"
+            ):  # Gotta redo these!
+                parseIt = True
+                KibbleBit.pprint(
+                    "[%s] Ticket contains erroneous data from a previous scan, reparsing"
+                    % key
+                )
+            # This is just noise!
+            # KibbleBit.pprint("[%s] Ticket hasn't changed, ignoring..." % key)
+
+    if parseIt:
+        KibbleBit.pprint("[%s] Parsing data from JIRA at %s..." % (key, domain))
+        queryURL = (
+            "%s/rest/api/2/issue/%s?fields=creator,reporter,status,issuetype,summary,assignee,resolutiondate,created,priority,changelog,comment,resolution,votes&expand=changelog"
+            % (u, key)
+        )
+        jiraURL = "%s/browse/%s" % (u, key)
+        try:
+            tjson = jsonapi.get(queryURL, auth=creds)
+            if not tjson:
+                KibbleBit.pprint("%s does not exist (404'ed)" % key)
+                return False
+        except requests.exceptions.ConnectionError as err:
+            KibbleBit.pprint("Connection error, skipping this ticket for now!")
+            return False
+        st, closer = wasclosed(tjson)
+        if st and not closer:
+            KibbleBit.pprint("Closed but no closer??")
+        closerEmail = None
+        status = "closed" if st else "open"
+
+        # Make sure we actually have field data to work with
+        if not tjson.get("fields") or not tjson["fields"].get("created"):
+            KibbleBit.pprint(
+                "[%s] JIRA response is missing field data, ignoring ticket." % key
+            )
+            return False
+
+        cd = getTime(tjson["fields"]["created"])
+        rd = (
+            getTime(tjson["fields"]["resolutiondate"])
+            if "resolutiondate" in tjson["fields"] and tjson["fields"]["resolutiondate"]
+            else None
+        )
+        comments = 0
+        if "comment" in tjson["fields"] and tjson["fields"]["comment"]:
+            comments = tjson["fields"]["comment"]["total"]
+        assignee = (
+            tjson["fields"]["assignee"].get(
+                "emailAddress",  # Try email, fall back to username
+                tjson["fields"]["assignee"].get("name"),
+            )
+            if tjson["fields"].get("assignee")
+            else None
+        )
+        creator = (
+            tjson["fields"]["reporter"].get(
+                "emailAddress",  # Try email, fall back to username
+                tjson["fields"]["reporter"].get("name"),
+            )
+            if tjson["fields"].get("reporter")
+            else None
+        )
+        title = tjson["fields"]["summary"]
+        if closer:
+            # print("Parsing closer")
+            closerEmail = (
+                closer.get("emailAddress", closer.get("name"))
+                .replace(" dot ", ".", 10)
+                .replace(" at ", "@", 1)
+            )
+            if not "@" in closerEmail:
+                closerEmail = "%s@%s" % (closerEmail, domain)
+            displayName = closer.get("displayName", "Unkown")
+            if displayName and len(displayName) > 0:
+                # Add to people db
+                pid = hashlib.sha1(
+                    ("%s%s" % (source["organisation"], closerEmail)).encode(
+                        "ascii", errors="replace"
+                    )
+                ).hexdigest()
+                jsp = {
+                    "name": displayName,
+                    "email": closerEmail,
+                    "organisation": source["organisation"],
+                    "id": pid,
+                    "upsert": True,
+                }
+                KibbleBit.append("person", jsp)
+
+        if creator:
+            creator = creator.replace(" dot ", ".", 10).replace(" at ", "@", 1)
+            if not "@" in creator:
+                creator = "%s@%s" % (creator, domain)
+            displayName = (
+                tjson["fields"]["reporter"]["displayName"]
+                if tjson["fields"]["reporter"]
+                else None
+            )
+            if displayName and len(displayName) > 0:
+                # Add to people db
+                pid = hashlib.sha1(
+                    ("%s%s" % (source["organisation"], creator)).encode(
+                        "ascii", errors="replace"
+                    )
+                ).hexdigest()
+                jsp = {
+                    "name": displayName,
+                    "email": creator,
+                    "organisation": source["organisation"],
+                    "id": pid,
+                    "upsert": True,
+                }
+                KibbleBit.append("person", jsp)
+        if assignee and not "@" in assignee:
+            assignee = "%s@%s" % (assignee, domain)
+        jso = {
+            "id": dhash,
+            "key": key,
+            "organisation": source["organisation"],
+            "sourceID": source["sourceID"],
+            "url": jiraURL,
+            "status": status,
+            "created": cd,
+            "closed": rd,
+            "issuetype": "issue",
+            "issueCloser": closerEmail,
+            "createdDate": time.strftime("%Y/%m/%d %H:%M:%S", time.gmtime(cd)),
+            "closedDate": time.strftime("%Y/%m/%d %H:%M:%S", time.gmtime(rd))
+            if rd
+            else None,
+            "changeDate": time.strftime(
+                "%Y/%m/%d %H:%M:%S", time.gmtime(rd if rd else cd)
+            ),
+            "assignee": assignee,
+            "issueCreator": creator,
+            "comments": comments,
+            "title": title,
+        }
+        KibbleBit.append("issue", jso)
+    return True
+
+
+#
+# except Exception as err:
+# KibbleBit.pprint(err)
+# return False
+
+
+class jiraThread(threading.Thread):
+    def __init__(self, block, KibbleBit, source, creds, pt, ot):
+        super(jiraThread, self).__init__()
+        self.block = block
+        self.KibbleBit = KibbleBit
+        self.creds = creds
+        self.source = source
+        self.pendingTickets = pt
+        self.openTickets = ot
+
+    def run(self):
+        badOnes = 0
+        while len(self.pendingTickets) > 0 and badOnes <= 50:
+            # print("%u elements left to count" % len(pendingTickets))
+            self.block.acquire()
+            try:
+                rl = self.pendingTickets.pop(0)
+            except Exception as err:
+                self.block.release()
+                return
+            if not rl:
+                self.block.release()
+                return
+            self.block.release()
+            if not scanTicket(
+                self.KibbleBit, rl[0], rl[1], rl[2], self.creds, self.openTickets
+            ):
+                self.KibbleBit.pprint("[%s] This borked, trying another one" % rl[0])
+                badOnes += 1
+                if badOnes > 100:
+                    self.KibbleBit.pprint("Too many errors, bailing!")
+                    self.source["steps"]["issues"] = {
+                        "time": time.time(),
+                        "status": "Too many errors while parsing at "
+                        + time.strftime("%Y/%m/%d %H:%M:%S", time.gmtime(time.time())),
+                        "running": False,
+                        "good": False,
+                    }
+                    self.KibbleBit.updateSource(self.source)
+                    return
+            else:
+                badOnes = 0
+
+
+def scan(KibbleBit, source):
+    jira = re.match(r"(https?://.+)/browse/([A-Z0-9]+)", source["sourceURL"])
+    if jira:
+
+        # JIRA NEEDS credentials to do a proper scan!
+        creds = None
+        if (
+            source["creds"]
+            and "username" in source["creds"]
+            and source["creds"]["username"]
+            and len(source["creds"]["username"]) > 0
+        ):
+            creds = "%s:%s" % (source["creds"]["username"], source["creds"]["password"])
+        if not creds:
+            KibbleBit.pprint(
+                "JIRA at %s requires authentication, but none was found! Bailing."
+                % source["sourceURL"]
+            )
+            source["steps"]["issues"] = {
+                "time": time.time(),
+                "status": "Parsing JIRA changes...",
+                "running": True,
+                "good": True,
+            }
+            KibbleBit.updateSource(source)
+            return
+
+        source["steps"]["issues"] = {
+            "time": time.time(),
+            "status": "Parsing JIRA changes...",
+            "running": True,
+            "good": True,
+        }
+        KibbleBit.updateSource(source)
+
+        badOnes = 0
+        jsa = []
+        jsp = []
+        pendingTickets = []
+        KibbleBit.pprint("Parsing JIRA activity at %s" % source["sourceURL"])
+        source["steps"]["issues"] = {
+            "time": time.time(),
+            "status": "Downloading changeset",
+            "running": True,
+            "good": True,
+        }
+        KibbleBit.updateSource(source)
+
+        # Get base URL, list and domain to parse
+        u = jira.group(1)
+        instance = jira.group(2)
+        lastTicket = 0
+        latestURL = (
+            "%s/rest/api/2/search?jql=project=%s+order+by+createdDate+DESC&fields=id,key&maxResults=1"
+            % (u, instance)
+        )
+        js = None
+
+        js = jsonapi.get(latestURL, auth=creds)
+        if "issues" in js and len(js["issues"]) == 1:
+            key = js["issues"][0]["key"]
+            m = re.search(r"-(\d+)$", key)
+            if m:
+                lastTicket = int(m.group(1))
+
+        openTickets = []
+        startAt = 0
+        badTries = 0
+        while True and badTries < 10:
+            openURL = (
+                "%s/rest/api/2/search?jql=project=%s+and+status=open+order+by+createdDate+ASC&fields=id,key&maxResults=100&startAt=%u"
+                % (u, instance, startAt)
+            )
+            # print(openURL)
+            try:
+                ojs = jsonapi.get(openURL, auth=creds)
+                if not "issues" in ojs or len(ojs["issues"]) == 0:
+                    break
+                for item in ojs["issues"]:
+                    openTickets.append(item["key"])
+                KibbleBit.pprint("Found %u open tickets" % len(openTickets))
+                startAt += 100
+            except:
+                KibbleBit.pprint("JIRA borked, retrying")
+                badTries += 1
+        KibbleBit.pprint("Found %u open tickets" % len(openTickets))
+
+        badOnes = 0
+        for i in reversed(range(1, lastTicket + 1)):
+            key = "%s-%u" % (instance, i)
+            pendingTickets.append([key, u, source])
+
+        threads = []
+        block = threading.Lock()
+        KibbleBit.pprint("Scanning tickets using 4 sub-threads")
+        for i in range(0, 4):
+            t = jiraThread(block, KibbleBit, source, creds, pendingTickets, openTickets)
+            threads.append(t)
+            t.start()
+
+        for t in threads:
+            t.join()
+
+        KibbleBit.pprint("Done scanning %s" % source["sourceURL"])
+
+        source["steps"]["issues"] = {
+            "time": time.time(),
+            "status": "Issue tracker (JIRA) successfully scanned at "
+            + time.strftime("%Y/%m/%d %H:%M:%S", time.gmtime(time.time())),
+            "running": False,
+            "good": True,
+        }
+        KibbleBit.updateSource(source)

--- a/kibble/scanners/scanners/pipermail.py
+++ b/kibble/scanners/scanners/pipermail.py
@@ -1,0 +1,295 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import mailbox
+import email.errors
+import email.utils
+import email.header
+import time
+import re
+import os
+import hashlib
+import datetime
+
+from kibble.scanners.utils import urlmisc
+
+title = "Scanner for GNU Mailman Pipermail"
+version = "0.1.0"
+
+
+def accepts(source):
+    """ Whether or not we think this is pipermail """
+    if source["type"] == "pipermail":
+        return True
+    if source["type"] == "mail":
+        url = source["sourceURL"]
+        pipermail = re.match(r"(https?://.+/(archives|pipermail)/.+?)/?$", url)
+        if pipermail:
+            return True
+    return False
+
+
+def scan(KibbleBit, source):
+    url = source["sourceURL"]
+    pipermail = re.match(r"(https?://.+/(archives|pipermail)/.+?)/?$", url)
+    if pipermail:
+        KibbleBit.pprint("Scanning Pipermail source %s" % url)
+        skipped = 0
+        jsa = []
+        jsp = []
+        source["steps"]["mail"] = {
+            "time": time.time(),
+            "status": "Downloading Pipermail statistics",
+            "running": True,
+            "good": True,
+        }
+        KibbleBit.updateSource(source)
+
+        dt = time.gmtime(time.time())
+        firstYear = 1970
+        year = dt[0]
+        month = dt[1]
+        if month <= 0:
+            month += 12
+            year -= 1
+        months = 0
+
+        knowns = {}
+
+        # While we have older archives, continue to parse
+        monthNames = [
+            "December",
+            "January",
+            "February",
+            "March",
+            "April",
+            "May",
+            "June",
+            "July",
+            "August",
+            "September",
+            "October",
+            "November",
+            "December",
+        ]
+        while firstYear <= year:
+            gzurl = "%s/%04u-%s.txt.gz" % (url, year, monthNames[month])
+            pd = datetime.date(year, month, 1).timetuple()
+            dhash = hashlib.sha224(
+                (("%s %s") % (source["organisation"], gzurl)).encode(
+                    "ascii", errors="replace"
+                )
+            ).hexdigest()
+            found = False
+            found = KibbleBit.exists("mailstats", dhash)
+            if (
+                months <= 1 or not found
+            ):  # Always parse this month's stats and the previous month :)
+                months += 1
+                mailFile = urlmisc.unzip(gzurl)
+                if mailFile:
+                    try:
+                        skipped = 0
+                        messages = mailbox.mbox(mailFile)
+
+                        rawtopics = {}
+                        posters = {}
+                        no_posters = 0
+                        emails = 0
+                        senders = {}
+                        for message in messages:
+                            emails += 1
+                            sender = message["from"]
+                            name = sender
+                            if (
+                                not "subject" in message
+                                or not message["subject"]
+                                or not "from" in message
+                                or not message["from"]
+                            ):
+                                continue
+
+                            irt = message.get("in-reply-to", None)
+                            if not irt and message.get("references"):
+                                irt = message.get("references").split("\n")[0].strip()
+                            replyto = None
+                            if irt and irt in senders:
+                                replyto = senders[irt]
+                                print("This is a reply to %s" % replyto)
+                            raw_subject = re.sub(
+                                r"^[a-zA-Z]+\s*:\s*", "", message["subject"], count=10
+                            )
+                            raw_subject = re.sub(
+                                r"[\r\n\t]+", "", raw_subject, count=10
+                            )
+                            if not raw_subject in rawtopics:
+                                rawtopics[raw_subject] = 0
+                            rawtopics[raw_subject] += 1
+                            m = re.match(
+                                r"(.+?) at (.+?) \((.*)\)$",
+                                message["from"],
+                                flags=re.UNICODE,
+                            )
+                            if m:
+                                name = m.group(3).strip()
+                                sender = m.group(1) + "@" + m.group(2)
+                            else:
+                                m = re.match(
+                                    r"(.+)\s*<(.+)>", message["from"], flags=re.UNICODE
+                                )
+                                if m:
+                                    name = m.group(1).replace('"', "").strip()
+                                    sender = m.group(2)
+                            if not sender in posters:
+                                posters[sender] = {"name": name, "email": sender}
+                            senders[message.get("message-id", "??")] = sender
+                            mdate = email.utils.parsedate_tz(message["date"])
+                            mdatestring = time.strftime(
+                                "%Y/%m/%d %H:%M:%S",
+                                time.gmtime(email.utils.mktime_tz(mdate)),
+                            )
+                            if not sender in knowns:
+                                sid = hashlib.sha1(
+                                    ("%s%s" % (source["organisation"], sender)).encode(
+                                        "ascii", errors="replace"
+                                    )
+                                ).hexdigest()
+                                knowns[sender] = KibbleBit.exists("person", sid)
+                            if not sender in knowns:
+                                KibbleBit.append(
+                                    "person",
+                                    {
+                                        "name": name,
+                                        "email": sender,
+                                        "organisation": source["organisation"],
+                                        "id": hashlib.sha1(
+                                            (
+                                                "%s%s"
+                                                % (source["organisation"], sender)
+                                            ).encode("ascii", errors="replace")
+                                        ).hexdigest(),
+                                    },
+                                )
+                                knowns[sender] = True
+                            jse = {
+                                "organisation": source["organisation"],
+                                "sourceURL": source["sourceURL"],
+                                "sourceID": source["sourceID"],
+                                "date": mdatestring,
+                                "sender": sender,
+                                "replyto": replyto,
+                                "subject": message["subject"],
+                                "address": sender,
+                                "ts": email.utils.mktime_tz(mdate),
+                                "id": message["message-id"],
+                            }
+                            KibbleBit.append("email", jse)
+
+                        for sender in posters:
+                            no_posters += 1
+                        i = 0
+                        topics = 0
+                        for key in rawtopics:
+                            topics += 1
+                        for key in reversed(sorted(rawtopics, key=lambda x: x)):
+                            val = rawtopics[key]
+                            i += 1
+                            if i > 10:
+                                break
+                            KibbleBit.pprint(
+                                "Found top 10: %s (%s emails)" % (key, val)
+                            )
+                            shash = hashlib.sha224(
+                                key.encode("ascii", errors="replace")
+                            ).hexdigest()
+                            md = time.strftime("%Y/%m/%d %H:%M:%S", pd)
+                            mlhash = hashlib.sha224(
+                                (
+                                    ("%s%s%s%s")
+                                    % (
+                                        key,
+                                        source["sourceURL"],
+                                        source["organisation"],
+                                        md,
+                                    )
+                                ).encode("ascii", errors="replace")
+                            ).hexdigest()  # one unique id per month per mail thread
+                            jst = {
+                                "organisation": source["organisation"],
+                                "sourceURL": source["sourceURL"],
+                                "sourceID": source["sourceID"],
+                                "date": md,
+                                "emails": val,
+                                "shash": shash,
+                                "subject": key,
+                                "ts": time.mktime(pd),
+                                "id": mlhash,
+                            }
+                            KibbleBit.index("mailtop", mlhash, jst)
+
+                        jso = {
+                            "organisation": source["organisation"],
+                            "sourceURL": source["sourceURL"],
+                            "sourceID": source["sourceID"],
+                            "date": time.strftime("%Y/%m/%d %H:%M:%S", pd),
+                            "authors": no_posters,
+                            "emails": emails,
+                            "topics": topics,
+                        }
+                        KibbleBit.index("mailstats", dhash, jso)
+
+                        os.unlink(mailFile)
+                    except Exception as err:
+                        KibbleBit.pprint(
+                            "Couldn't parse %s, skipping: %s" % (gzurl, err)
+                        )
+                        skipped += 1
+                        if skipped > 12:
+                            KibbleBit.pprint(
+                                "12 skips in a row, breaking off (no more data?)"
+                            )
+                            break
+                else:
+                    KibbleBit.pprint("Couldn't find %s, skipping." % gzurl)
+                    skipped += 1
+                    if skipped > 12:
+                        KibbleBit.pprint(
+                            "12 skips in a row, breaking off (no more data?)"
+                        )
+                        break
+            month -= 1
+            if month <= 0:
+                month += 12
+                year -= 1
+
+        source["steps"]["mail"] = {
+            "time": time.time(),
+            "status": "Mail archives successfully scanned at "
+            + time.strftime("%Y/%m/%d %H:%M:%S", time.gmtime(time.time())),
+            "running": False,
+            "good": True,
+        }
+        KibbleBit.updateSource(source)
+    else:
+        KibbleBit.pprint("Invalid Pipermail URL detected: %s" % url, True)
+        source["steps"]["mail"] = {
+            "time": time.time(),
+            "status": "Invalid or malformed URL detected!",
+            "running": False,
+            "good": False,
+        }
+        KibbleBit.updateSource(source)

--- a/kibble/scanners/scanners/ponymail-kpe.py
+++ b/kibble/scanners/scanners/ponymail-kpe.py
@@ -1,0 +1,134 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import time
+import re
+
+from kibble.scanners.utils import jsonapi, kpe
+
+"""
+This is a Kibble scanner plugin for Apache Pony Mail sources.
+"""
+
+title = "Key Phrase Extraction plugin for Apache Pony Mail"
+version = "0.1.0"
+ROBITS = r"(git|gerrit|jenkins|hudson|builds|bugzilla)@"
+MAX_COUNT = (
+    100
+)  # Max number of unparsed emails to handle (so we don't max out API credits!)
+
+
+def accepts(source):
+    """ Test if source matches a Pony Mail archive """
+    # If the source equals the plugin name, assume a yes
+    if source["type"] == "ponymail":
+        return True
+
+    # If it's of type 'mail', check the URL
+    if source["type"] == "mail":
+        if re.match(r"(https?://.+)/list\.html\?(.+)@(.+)", source["sourceURL"]):
+            return True
+
+    # Default to not recognizing the source
+    return False
+
+
+def scan(KibbleBit, source):
+    # Validate URL first
+    url = re.match(r"(https?://.+)/list\.html\?(.+)@(.+)", source["sourceURL"])
+    if not url:
+        KibbleBit.pprint(
+            "Malformed or invalid Pony Mail URL passed to scanner: %s"
+            % source["sourceURL"]
+        )
+        source["steps"]["mail"] = {
+            "time": time.time(),
+            "status": "Could not parse Pony Mail URL!",
+            "running": False,
+            "good": False,
+        }
+        KibbleBit.updateSource(source)
+        return
+
+    if not "azure" in KibbleBit.config and not "picoapi" in KibbleBit.config:
+        KibbleBit.pprint(
+            "No Azure/picoAPI creds configured, skipping key phrase extraction"
+        )
+        return
+
+    cookie = None
+    if "creds" in source and source["creds"]:
+        cookie = source["creds"].get("cookie", None)
+
+    rootURL = re.sub(r"list.html.+", "", source["sourceURL"])
+    query = {
+        "query": {"bool": {"must": [{"term": {"sourceID": source["sourceID"]}}]}},
+        "sort": [{"ts": "desc"}],
+    }
+
+    # Get an initial count of commits
+    res = KibbleBit.broker.DB.search(
+        index=KibbleBit.dbname, doc_type="email", body=query, size=MAX_COUNT * 4
+    )
+    ec = 0
+    hits = []
+    for hit in res["hits"]["hits"]:
+        eml = hit["_source"]
+        if not re.search(ROBITS, eml["sender"]):
+            ec += 1
+            if ec > MAX_COUNT:
+                break
+            if "kpe" not in eml:
+                emlurl = "%s/api/email.lua?id=%s" % (rootURL, eml["id"])
+                KibbleBit.pprint("Fetching %s" % emlurl)
+                rv = None
+                try:
+                    rv = jsonapi.get(emlurl, cookie=cookie)
+                    if rv and "body" in rv:
+                        hits.append([hit["_id"], rv["body"], eml])
+                except Exception as err:
+                    KibbleBit.pprint("Server error, skipping this email")
+
+    bodies = []
+    for hit in hits:
+        body = hit[1]
+        bid = hit[0]
+        bodies.append(body)
+    if bodies:
+        if "watson" in KibbleBit.config:
+            pass  # Haven't written this yet
+        elif "azure" in KibbleBit.config:
+            KPEs = kpe.azureKPE(KibbleBit, bodies)
+        elif "picoapi" in KibbleBit.config:
+            KPEs = kpe.picoKPE(KibbleBit, bodies)
+        if KPEs == False:
+            KibbleBit.pprint("Hit rate limit, not trying further emails for now.")
+
+        a = 0
+        for hit in hits:
+            kpe_ = KPEs[a]
+            bid = hit[0]
+            eml = hit[2]
+            a += 1
+            if not kpe_:
+                kpe_ = ["_NULL_"]
+            eml["kpe"] = kpe_
+            print("Key phrases for %s: %s" % (bid, ", ".join(kpe_)))
+            KibbleBit.index("email", bid, eml)
+    else:
+        KibbleBit.pprint("No emails to analyze")
+    KibbleBit.pprint("Done with key phrase extraction")

--- a/kibble/scanners/scanners/ponymail-tone.py
+++ b/kibble/scanners/scanners/ponymail-tone.py
@@ -1,0 +1,137 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""
+This is a Kibble scanner plugin for Apache Pony Mail sources.
+"""
+import time
+import re
+
+from kibble.scanners.utils import jsonapi, tone
+
+title = "Tone/Mood Scanner plugin for Apache Pony Mail"
+version = "0.1.0"
+ROBITS = r"(git|gerrit|jenkins|hudson|builds|bugzilla)@"
+MAX_COUNT = 250
+
+
+def accepts(source):
+    """ Test if source matches a Pony Mail archive """
+    # If the source equals the plugin name, assume a yes
+    if source["type"] == "ponymail":
+        return True
+
+    # If it's of type 'mail', check the URL
+    if source["type"] == "mail":
+        if re.match(r"(https?://.+)/list\.html\?(.+)@(.+)", source["sourceURL"]):
+            return True
+
+    # Default to not recognizing the source
+    return False
+
+
+def scan(KibbleBit, source):
+    # Validate URL first
+    url = re.match(r"(https?://.+)/list\.html\?(.+)@(.+)", source["sourceURL"])
+    if not url:
+        KibbleBit.pprint(
+            "Malformed or invalid Pony Mail URL passed to scanner: %s"
+            % source["sourceURL"]
+        )
+        source["steps"]["mail"] = {
+            "time": time.time(),
+            "status": "Could not parse Pony Mail URL!",
+            "running": False,
+            "good": False,
+        }
+        KibbleBit.updateSource(source)
+        return
+
+    if (
+        not "watson" in KibbleBit.config
+        and not "azure" in KibbleBit.config
+        and not "picoapi" in KibbleBit.config
+    ):
+        KibbleBit.pprint(
+            "No Watson/Azure/picoAPI creds configured, skipping tone analyzer"
+        )
+        return
+
+    cookie = None
+    if "creds" in source and source["creds"]:
+        cookie = source["creds"].get("cookie", None)
+
+    rootURL = re.sub(r"list.html.+", "", source["sourceURL"])
+    query = {
+        "query": {"bool": {"must": [{"term": {"sourceID": source["sourceID"]}}]}},
+        "sort": [{"ts": "desc"}],
+    }
+
+    # Get an initial count of commits
+    res = KibbleBit.broker.DB.search(
+        index=KibbleBit.dbname, doc_type="email", body=query, size=MAX_COUNT * 4
+    )
+    ec = 0
+    hits = []
+    for hit in res["hits"]["hits"]:
+        eml = hit["_source"]
+        if not re.search(ROBITS, eml["sender"]):
+            ec += 1
+            if ec > MAX_COUNT:
+                break
+            if "mood" not in eml:
+                emlurl = "%s/api/email.lua?id=%s" % (rootURL, eml["id"])
+                KibbleBit.pprint("Fetching %s" % emlurl)
+                rv = None
+                try:
+                    rv = jsonapi.get(emlurl, cookie=cookie)
+                    if rv and "body" in rv:
+                        hits.append([hit["_id"], rv["body"], eml])
+                except Exception as err:
+                    KibbleBit.pprint("Server error, skipping this email")
+
+    bodies = []
+    for hit in hits:
+        body = hit[1]
+        bid = hit[0]
+        bodies.append(body)
+    if bodies:
+        if "watson" in KibbleBit.config:
+            moods = tone.watsonTone(KibbleBit, bodies)
+        elif "azure" in KibbleBit.config:
+            moods = tone.azureTone(KibbleBit, bodies)
+        elif "picoapi" in KibbleBit.config:
+            moods = tone.picoTone(KibbleBit, bodies)
+        if moods == False:
+            KibbleBit.pprint("Hit rate limit, not trying further emails for now.")
+
+        a = 0
+        for hit in hits:
+            mood = moods[a]
+            bid = hit[0]
+            eml = hit[2]
+            a += 1
+            eml["mood"] = mood
+            hm = [0, "unknown"]
+            for m, s in mood.items():
+                if s > hm[0]:
+                    hm = [s, m]
+            print("Likeliest overall mood for %s: %s" % (bid, hm[1]))
+            KibbleBit.index("email", bid, eml)
+    else:
+        KibbleBit.pprint("No emails to analyze")
+    KibbleBit.pprint("Done with tone analysis")

--- a/kibble/scanners/scanners/ponymail.py
+++ b/kibble/scanners/scanners/ponymail.py
@@ -1,0 +1,309 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import time
+import re
+import hashlib
+import datetime
+
+from kibble.scanners.utils import jsonapi
+
+"""
+This is a Kibble scanner plugin for Apache Pony Mail sources.
+"""
+
+title = "Scanner plugin for Apache Pony Mail"
+version = "0.1.0"
+
+
+def accepts(source):
+    """ Test if source matches a Pony Mail archive """
+    # If the source equals the plugin name, assume a yes
+    if source["type"] == "ponymail":
+        return True
+
+    # If it's of type 'mail', check the URL
+    if source["type"] == "mail":
+        if re.match(r"(https?://.+)/list\.html\?(.+)@(.+)", source["sourceURL"]):
+            return True
+
+    # Default to not recognizing the source
+    return False
+
+
+def countSubs(struct, kids=0):
+    """ Counts replies in a thread """
+    if "children" in struct and len(struct["children"]) > 0:
+        for child in struct["children"]:
+            kids += 1
+            kids += countSubs(child)
+    return kids
+
+
+def repliedTo(emails, struct):
+    myList = {}
+    for eml in struct:
+        myID = eml["tid"]
+        if "children" in eml:
+            for child in eml["children"]:
+                myList[child["tid"]] = myID
+                if len(child["children"]) > 0:
+                    cList = repliedTo(emails, child["children"])
+                    myList.update(cList)
+    return myList
+
+
+def getSender(email):
+    sender = email["from"]
+    name = sender
+    m = re.match(r"(.+)\s*<(.+)>", email["from"], flags=re.UNICODE)
+    if m:
+        name = m.group(1).replace('"', "").strip()
+        sender = m.group(2)
+    return sender
+
+
+def scan(KibbleBit, source):
+    # Validate URL first
+    url = re.match(r"(https?://.+)/list\.html\?(.+)@(.+)", source["sourceURL"])
+    if not url:
+        KibbleBit.pprint(
+            "Malformed or invalid Pony Mail URL passed to scanner: %s"
+            % source["sourceURL"]
+        )
+        source["steps"]["mail"] = {
+            "time": time.time(),
+            "status": "Could not parse Pony Mail URL!",
+            "running": False,
+            "good": False,
+        }
+        KibbleBit.updateSource(source)
+        return
+
+    # Pony Mail requires a UI cookie in order to work. Maked sure we have one!
+    cookie = None
+    if "creds" in source and source["creds"]:
+        cookie = source["creds"].get("cookie", None)
+    if not cookie:
+        KibbleBit.pprint(
+            "Pony Mail instance at %s requires an authorized cookie, none found! Bailing."
+            % source["sourceURL"]
+        )
+        source["steps"]["mail"] = {
+            "time": time.time(),
+            "status": "No authorized cookie found in source object.",
+            "running": False,
+            "good": False,
+        }
+        KibbleBit.updateSource(source)
+        return
+
+    # Notify scanner and DB that this is valid and we've begun parsing
+    KibbleBit.pprint("%s is a valid Pony Mail address, parsing" % source["sourceURL"])
+    source["steps"]["mail"] = {
+        "time": time.time(),
+        "status": "Downloading Pony Mail statistics",
+        "running": True,
+        "good": True,
+    }
+    KibbleBit.updateSource(source)
+
+    # Get base URL, list and domain to parse
+    u = url.group(1)
+    l = url.group(2)
+    d = url.group(3)
+
+    # Get this month
+    dt = time.gmtime(time.time())
+    firstYear = 1970
+    year = dt[0]
+    month = dt[1]
+    if month <= 0:
+        month += 12
+        year -= 1
+    months = 0
+
+    # Hash for keeping records of who we know
+    knowns = {}
+
+    # While we have older archives, continue to parse
+    while firstYear <= year:
+        statsurl = "%s/api/stats.lua?list=%s&domain=%s&d=%s" % (
+            u,
+            l,
+            d,
+            "%04u-%02u" % (year, month),
+        )
+        dhash = hashlib.sha224(
+            (("%s %s") % (source["organisation"], statsurl)).encode(
+                "ascii", errors="replace"
+            )
+        ).hexdigest()
+        found = False
+        if KibbleBit.exists("mailstats", dhash):
+            found = True
+        if months <= 1 or not found:  # Always parse this month's stats :)
+            months += 1
+            KibbleBit.pprint("Parsing %04u-%02u" % (year, month))
+            KibbleBit.pprint(statsurl)
+            pd = datetime.date(year, month, 1).timetuple()
+            try:
+                js = jsonapi.get(statsurl, cookie=cookie)
+            except Exception as err:
+                KibbleBit.pprint("Server error, skipping this month")
+                month -= 1
+                if month <= 0:
+                    month += 12
+                    year -= 1
+                continue
+            if "firstYear" in js:
+                firstYear = js["firstYear"]
+                # print("First Year is %u" % firstYear)
+            else:
+                KibbleBit.pprint("JSON was missing fields, aborting!")
+                break
+            replyList = repliedTo(js["emails"], js["thread_struct"])
+            topics = js["no_threads"]
+            posters = {}
+            no_posters = 0
+            emails = len(js["emails"])
+            top10 = []
+            for eml in js["thread_struct"]:
+                count = countSubs(eml, 0)
+                subject = ""
+                for reml in js["emails"]:
+                    if reml["id"] == eml["tid"]:
+                        subject = reml["subject"]
+                        break
+                if len(subject) > 0 and count > 0:
+                    subject = re.sub(
+                        r"^((re|fwd|aw|fw):\s*)+", "", subject, flags=re.IGNORECASE
+                    )
+                    subject = re.sub(r"[\r\n\t]+", "", subject, count=20)
+                    emlid = hashlib.sha1(
+                        subject.encode("ascii", errors="replace")
+                    ).hexdigest()
+                    top10.append([emlid, subject, count])
+            i = 0
+            for top in reversed(sorted(top10, key=lambda x: x[2])):
+                i += 1
+                if i > 10:
+                    break
+                KibbleBit.pprint("Found top 10: %s (%s emails)" % (top[1], top[2]))
+                md = time.strftime("%Y/%m/%d %H:%M:%S", pd)
+                mlhash = hashlib.sha224(
+                    (
+                        ("%s%s%s%s")
+                        % (top[0], source["sourceURL"], source["organisation"], md)
+                    ).encode("ascii", errors="replace")
+                ).hexdigest()  # one unique id per month per mail thread
+                jst = {
+                    "organisation": source["organisation"],
+                    "sourceURL": source["sourceURL"],
+                    "sourceID": source["sourceID"],
+                    "date": md,
+                    "emails": top[2],
+                    "shash": top[0],
+                    "subject": top[1],
+                    "ts": time.mktime(pd),
+                    "id": mlhash,
+                }
+                KibbleBit.index("mailtop", mlhash, jst)
+
+            for email in js["emails"]:
+                sender = email["from"]
+                name = sender
+                m = re.match(r"(.+)\s*<(.+)>", email["from"], flags=re.UNICODE)
+                if m:
+                    name = m.group(1).replace('"', "").strip()
+                    sender = m.group(2)
+                if not sender in posters:
+                    posters[sender] = {"name": name, "email": sender}
+                if not sender in knowns:
+                    sid = hashlib.sha1(
+                        ("%s%s" % (source["organisation"], sender)).encode(
+                            "ascii", errors="replace"
+                        )
+                    ).hexdigest()
+                    if KibbleBit.exists("person", sid):
+                        knowns[sender] = True
+                if not sender in knowns or name != sender:
+                    KibbleBit.append(
+                        "person",
+                        {
+                            "upsert": True,
+                            "name": name,
+                            "email": sender,
+                            "organisation": source["organisation"],
+                            "id": hashlib.sha1(
+                                ("%s%s" % (source["organisation"], sender)).encode(
+                                    "ascii", errors="replace"
+                                )
+                            ).hexdigest(),
+                        },
+                    )
+                    knowns[sender] = True
+                replyTo = None
+                if email["id"] in replyList:
+                    rt = replyList[email["id"]]
+                    for eml in js["emails"]:
+                        if eml["id"] == rt:
+                            replyTo = getSender(eml)
+                            print("Email was reply to %s" % sender)
+                jse = {
+                    "organisation": source["organisation"],
+                    "sourceURL": source["sourceURL"],
+                    "sourceID": source["sourceID"],
+                    "date": time.strftime(
+                        "%Y/%m/%d %H:%M:%S", time.gmtime(email["epoch"])
+                    ),
+                    "sender": sender,
+                    "address": sender,
+                    "subject": email["subject"],
+                    "replyto": replyTo,
+                    "ts": email["epoch"],
+                    "id": email["id"],
+                    "upsert": True,
+                }
+                KibbleBit.append("email", jse)
+            for sender in posters:
+                no_posters += 1
+
+            jso = {
+                "organisation": source["organisation"],
+                "sourceURL": source["sourceURL"],
+                "sourceID": source["sourceID"],
+                "date": time.strftime("%Y/%m/%d %H:%M:%S", pd),
+                "authors": no_posters,
+                "emails": emails,
+                "topics": topics,
+            }
+            # print("Indexing as %s" % dhash)
+            KibbleBit.index("mailstats", dhash, jso)
+        month -= 1
+        if month <= 0:
+            month += 12
+            year -= 1
+
+    source["steps"]["mail"] = {
+        "time": time.time(),
+        "status": "Mail archives successfully scanned at "
+        + time.strftime("%Y/%m/%d %H:%M:%S", time.gmtime(time.time())),
+        "running": False,
+        "good": True,
+    }
+    KibbleBit.updateSource(source)

--- a/kibble/scanners/scanners/travis.py
+++ b/kibble/scanners/scanners/travis.py
@@ -1,0 +1,393 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import time
+import datetime
+import re
+import hashlib
+import threading
+import requests
+import requests.exceptions
+
+"""
+This is the Kibble Travis CI scanner plugin.
+"""
+
+title = "Scanner for Travis CI"
+version = "0.1.0"
+
+
+def accepts(source):
+    """ Determines whether we want to handle this source """
+    if source["type"] == "travis":
+        return True
+    return False
+
+
+def scanJob(KibbleBit, source, bid, token, TLD):
+    """ Scans a single job for activity """
+    NOW = int(datetime.datetime.utcnow().timestamp())
+    dhash = hashlib.sha224(
+        ("%s-%s-%s" % (source["organisation"], source["sourceURL"], bid)).encode(
+            "ascii", errors="replace"
+        )
+    ).hexdigest()
+    found = True
+    doc = None
+    parseIt = False
+    found = KibbleBit.exists("cijob", dhash)
+
+    # Get the job data
+    pages = 0
+    offset = 0
+    last_page = False
+    oURL = "https://api.travis-ci.%s/repo/%s/builds" % (TLD, bid)
+
+    # For as long as pagination makes sense...
+    while last_page == False:
+        bURL = "https://api.travis-ci.%s/repo/%s/builds?limit=100&offset=%u" % (
+            TLD,
+            bid,
+            offset,
+        )
+        KibbleBit.pprint("Scanning %s" % bURL)
+        rv = requests.get(
+            bURL,
+            headers={"Travis-API-Version": "3", "Authorization": "token %s" % token},
+        )
+        if rv.status_code == 200:
+            repojs = rv.json()
+            # If travis tells us it's the last page, trust it.
+            if repojs["@pagination"]["is_last"]:
+                KibbleBit.pprint(
+                    "Assuming this is the last page we need (travis says so)"
+                )
+                last_page = True
+
+            KibbleBit.pprint(
+                "%s has %u builds done" % (bURL, repojs["@pagination"]["count"])
+            )
+
+            # BREAKER: If we go past count somehow, and travis doesn't say so, bork anyway
+            if repojs["@pagination"]["count"] < offset:
+                return True
+
+            offset += 100
+            for build in repojs.get("builds", []):
+                buildID = build["id"]
+                buildProject = build["repository"]["slug"]
+                startedAt = build["started_at"]
+                finishedAt = build["finished_at"]
+                duration = build["duration"]
+                completed = True if duration else False
+                duration = duration or 0
+
+                buildhash = hashlib.sha224(
+                    (
+                        "%s-%s-%s-%s"
+                        % (source["organisation"], source["sourceURL"], bid, buildID)
+                    ).encode("ascii", errors="replace")
+                ).hexdigest()
+                builddoc = None
+                try:
+                    builddoc = KibbleBit.get("ci_build", buildhash)
+                except:
+                    pass
+
+                # If this build already completed, no need to parse it again
+                if builddoc and builddoc.get("completed", False):
+                    # If we're on page > 1 and we've seen a completed build, assume
+                    # that we don't need the older ones
+                    if pages > 1:
+                        KibbleBit.pprint(
+                            "Assuming this is the last page we need (found completed build on page > 1)"
+                        )
+                        last_page = True
+                        break
+                    continue
+
+                # Get build status (success, failed, canceled etc)
+                status = "building"
+                if build["state"] in ["finished", "passed"]:
+                    status = "success"
+                if build["state"] in ["failed", "errored"]:
+                    status = "failed"
+                if build["state"] in ["aborted", "canceled"]:
+                    status = "aborted"
+
+                FIN = 0
+                STA = 0
+                if finishedAt:
+                    FIN = datetime.datetime.strptime(
+                        finishedAt, "%Y-%m-%dT%H:%M:%SZ"
+                    ).timestamp()
+                if startedAt:
+                    STA = int(
+                        datetime.datetime.strptime(
+                            startedAt, "%Y-%m-%dT%H:%M:%SZ"
+                        ).timestamp()
+                    )
+
+                # We don't know how to calc queues yet, set to 0
+                queuetime = 0
+
+                doc = {
+                    # Build specific data
+                    "id": buildhash,
+                    "date": time.strftime("%Y/%m/%d %H:%M:%S", time.gmtime(FIN)),
+                    "buildID": buildID,
+                    "completed": completed,
+                    "duration": duration * 1000,
+                    "job": buildProject,
+                    "jobURL": oURL,
+                    "status": status,
+                    "started": STA,
+                    "ci": "travis",
+                    "queuetime": queuetime,
+                    # Standard docs values
+                    "sourceID": source["sourceID"],
+                    "organisation": source["organisation"],
+                    "upsert": True,
+                }
+                KibbleBit.append("ci_build", doc)
+            pages += 1
+        else:
+            # We hit a snag, abort!
+            KibbleBit.pprint("Travis returned a non-200 response, aborting.")
+            return False
+
+    return True
+
+
+class travisThread(threading.Thread):
+    """ Generic thread class for scheduling multiple scans at once """
+
+    def __init__(self, block, KibbleBit, source, token, jobs, TLD):
+        super(travisThread, self).__init__()
+        self.block = block
+        self.KibbleBit = KibbleBit
+        self.token = token
+        self.source = source
+        self.jobs = jobs
+        self.tld = TLD
+
+    def run(self):
+        badOnes = 0
+        while len(self.jobs) > 0 and badOnes <= 50:
+            self.block.acquire()
+            try:
+                job = self.jobs.pop(0)
+            except Exception as err:
+                self.block.release()
+                return
+            if not job:
+                self.block.release()
+                return
+            self.block.release()
+            if not scanJob(self.KibbleBit, self.source, job, self.token, self.tld):
+                self.KibbleBit.pprint("[%s] This borked, trying another one" % job)
+                badOnes += 1
+                if badOnes > 100:
+                    self.KibbleBit.pprint("Too many errors, bailing!")
+                    self.source["steps"]["travis"] = {
+                        "time": time.time(),
+                        "status": "Too many errors while parsing at "
+                        + time.strftime("%Y/%m/%d %H:%M:%S", time.gmtime(time.time())),
+                        "running": False,
+                        "good": False,
+                    }
+                    self.KibbleBit.updateSource(self.source)
+                    return
+            else:
+                badOnes = 0
+
+
+def scan(KibbleBit, source):
+    # Simple URL check
+    travis = re.match(r"https?://travis-ci\.(org|com)", source["sourceURL"])
+    if travis:
+        # Is this travs-ci.org or travis-ci.com - we need to know!
+        TLD = travis.group(1)
+        source["steps"]["travis"] = {
+            "time": time.time(),
+            "status": "Parsing Travis job changes...",
+            "running": True,
+            "good": True,
+        }
+        KibbleBit.updateSource(source)
+
+        badOnes = 0
+        pendingJobs = []
+        KibbleBit.pprint("Parsing Travis activity at %s" % source["sourceURL"])
+        source["steps"]["travis"] = {
+            "time": time.time(),
+            "status": "Downloading changeset",
+            "running": True,
+            "good": True,
+        }
+        KibbleBit.updateSource(source)
+
+        # Travis needs a token
+        token = None
+        if (
+            source["creds"]
+            and "token" in source["creds"]
+            and source["creds"]["token"]
+            and len(source["creds"]["token"]) > 0
+        ):
+            token = source["creds"]["token"]
+        else:
+            KibbleBit.pprint("Travis CI requires a token to work!")
+            return False
+
+        # Get the job list, paginated
+        sURL = source["sourceURL"]
+
+        # Used for pagination
+        jobs = 100
+        offset = 0
+
+        # Counters; builds queued, running and total jobs
+        queued = 0  # We don't know how to count this yet
+        building = 0
+        total = 0
+        blocked = 0  # Dunno how to count yet
+        stuck = 0  # Ditto
+        avgqueuetime = 0  # Ditto, fake it
+
+        maybeQueued = []
+        while jobs == 100:
+            URL = (
+                "https://api.travis-ci.%s/repos?repository.active=true&sort_by=current_build:desc&offset=%u&limit=100&include=repository.last_started_build"
+                % (TLD, offset)
+            )
+            offset += 100
+            r = requests.get(
+                URL,
+                headers={
+                    "Travis-API-Version": "3",
+                    "Authorization": "token %s" % token,
+                },
+            )
+
+            if r.status_code != 200:
+                KibbleBit.pprint("Travis did not return a 200 Okay, bad token?!")
+
+                source["steps"]["travis"] = {
+                    "time": time.time(),
+                    "status": "Travis CI scan failed at "
+                    + time.strftime(
+                        "%Y/%m/%d %H:%M:%S", time.gmtime(time.time()) + ". Bad token??!"
+                    ),
+                    "running": False,
+                    "good": False,
+                }
+                KibbleBit.updateSource(source)
+                return
+
+            # For each build job
+            js = r.json()
+            for repo in js["repositories"]:
+                total += 1
+                cb = repo.get("last_started_build")
+                if cb:
+                    # Is the build currently running?
+                    if cb["state"] in ["started", "created", "queued", "pending"]:
+                        for job in cb.get("jobs", []):
+                            maybeQueued.append(job["id"])
+
+                # Queue up build jobs for the threaded scanner
+                bid = repo["id"]
+                pendingJobs.append(bid)
+
+            jobs = len(js["repositories"])
+            KibbleBit.pprint("Scanned %u jobs..." % total)
+
+        # Find out how many building and pending jobs
+        for jobID in maybeQueued:
+            URL = "https://api.travis-ci.%s/job/%u" % (TLD, jobID)
+            r = requests.get(
+                URL,
+                headers={
+                    "Travis-API-Version": "3",
+                    "Authorization": "token %s" % token,
+                },
+            )
+            if r.status_code == 200:
+                jobjs = r.json()
+                if jobjs["state"] == "started":
+                    building += 1
+                    KibbleBit.pprint("Job %u is building" % jobID)
+                elif jobjs["state"] in ["created", "queued", "pending"]:
+                    queued += 1
+                    blocked += (
+                        1
+                    )  # Queued in Travis generally means a job can't find an executor, and thus is blocked.
+                    KibbleBit.pprint("Job %u is pending" % jobID)
+        KibbleBit.pprint("%u building, %u queued..." % (building, queued))
+
+        # Save queue snapshot
+        NOW = int(datetime.datetime.utcnow().timestamp())
+        queuehash = hashlib.sha224(
+            (
+                "%s-%s-queue-%s"
+                % (source["organisation"], source["sourceURL"], int(time.time()))
+            ).encode("ascii", errors="replace")
+        ).hexdigest()
+
+        # Write up a queue doc
+        queuedoc = {
+            "id": queuehash,
+            "date": time.strftime("%Y/%m/%d %H:%M:%S", time.gmtime(NOW)),
+            "time": NOW,
+            "building": building,
+            "size": queued,
+            "blocked": blocked,
+            "stuck": stuck,
+            "avgwait": avgqueuetime,
+            "ci": "travis",
+            # Standard docs values
+            "sourceID": source["sourceID"],
+            "organisation": source["organisation"],
+            "upsert": True,
+        }
+        KibbleBit.append("ci_queue", queuedoc)
+
+        KibbleBit.pprint("Found %u jobs in Travis" % len(pendingJobs))
+
+        threads = []
+        block = threading.Lock()
+        KibbleBit.pprint("Scanning jobs using 4 sub-threads")
+        for i in range(0, 4):
+            t = travisThread(block, KibbleBit, source, token, pendingJobs, TLD)
+            threads.append(t)
+            t.start()
+
+        for t in threads:
+            t.join()
+
+        # We're all done, yaay
+        KibbleBit.pprint("Done scanning %s" % source["sourceURL"])
+
+        source["steps"]["travis"] = {
+            "time": time.time(),
+            "status": "Travis successfully scanned at "
+            + time.strftime("%Y/%m/%d %H:%M:%S", time.gmtime(time.time())),
+            "running": False,
+            "good": True,
+        }
+        KibbleBit.updateSource(source)

--- a/kibble/scanners/scanners/twitter.py
+++ b/kibble/scanners/scanners/twitter.py
@@ -1,0 +1,149 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""
+This is a Kibble scanner plugin for Twitter sources.
+"""
+import time
+import hashlib
+import twitter
+
+title = "Scanner plugin for Twitter"
+version = "0.1.0"
+
+
+def accepts(source):
+    """ Test if source matches a Twitter handle """
+    # If the source equals the plugin name, assume a yes
+    if source["type"] == "twitter":
+        return True
+
+    # Default to not recognizing the source
+    return False
+
+
+def getFollowers(KibbleBit, source, t):
+    """ Get followers of a handle, store them for mapping and trend purposes"""
+    # Get our twitter handle
+    handle = source["sourceURL"]
+
+    # Get number of followers
+    tuser = t.GetUser(screen_name=handle)
+    no_followers = tuser.followers_count
+    d = time.strftime("%Y/%m/%d 0:00:00", time.gmtime())  # Today at midnight
+    dhash = hashlib.sha224(
+        (
+            ("twitter:%s:%s:%s") % (source["organisation"], source["sourceURL"], d)
+        ).encode("ascii", errors="replace")
+    ).hexdigest()
+    jst = {
+        "organisation": source["organisation"],
+        "sourceURL": source["sourceURL"],
+        "sourceID": source["sourceID"],
+        "id": dhash,
+        "followers": no_followers,
+        "date": d,
+    }
+    KibbleBit.pprint("%s has %u followers currently." % (handle, no_followers))
+    KibbleBit.index("twitter_followers", dhash, jst)
+
+    # Collect list of current followers
+    followers = t.GetFollowers(screen_name=handle)
+
+    # For each follower, if they're not mapped yet, add them
+    # This has a limitation of 100 new added per run, but meh...
+    KibbleBit.pprint("Looking up followers of %s" % handle)
+    for follower in followers:
+        # id, name, screen_name are useful here
+        KibbleBit.pprint("Found %s as follower" % follower.screen_name)
+
+        # Store twitter follower profile if not already logged
+        dhash = hashlib.sha224(
+            (
+                ("twitter:%s:%s:%s") % (source["organisation"], handle, follower.id)
+            ).encode("ascii", errors="replace")
+        ).hexdigest()
+        if not KibbleBit.exists("twitter_follow", dhash):
+            jst = {
+                "organisation": source["organisation"],
+                "sourceURL": source["sourceURL"],
+                "sourceID": source["sourceID"],
+                "twitterid": follower.id,
+                "name": follower.name,
+                "screenname": follower.screen_name,
+                "id": dhash,
+                "date": time.strftime(
+                    "%Y/%m/%d %H:%M:%S", time.gmtime()
+                ),  # First time we spotted them following.
+            }
+            KibbleBit.pprint(
+                "%s is new, recording date and details." % follower.screen_name
+            )
+            KibbleBit.index("twitter_follow", dhash, jst)
+
+
+def scan(KibbleBit, source):
+    source["steps"]["twitter"] = {
+        "time": time.time(),
+        "status": "Scanning Twitter activity and status",
+        "running": True,
+        "good": True,
+    }
+    KibbleBit.updateSource(source)
+    t = None
+    if "creds" in source and source["creds"]:
+        t = twitter.Api(
+            access_token_key=source["creds"].get("token", None),
+            access_token_secret=source["creds"].get("token_secret", None),
+            consumer_key=source["creds"].get("consumer_key", None),
+            consumer_secret=source["creds"].get("consumer_secret", None),
+        )
+        KibbleBit.pprint("Verrifying twitter credentials...")
+        try:
+            t.VerifyCredentials()
+        except:
+            source["steps"]["twitter"] = {
+                "time": time.time(),
+                "status": "Could not verify twitter credentials",
+                "running": False,
+                "good": False,
+            }
+            KibbleBit.updateSource(source)
+            KibbleBit.pprint("Could not verify twitter creds, aborting!")
+            return
+    # Start by getting and saving followers
+    try:
+        getFollowers(KibbleBit, source, t)
+    except Exception as err:
+        source["steps"]["twitter"] = {
+            "time": time.time(),
+            "status": "Could not scan Twitter: %s" % err,
+            "running": False,
+            "good": False,
+        }
+        KibbleBit.updateSource(source)
+        KibbleBit.pprint("Twitter scan failed: %s" % err)
+
+    # All done, report that!
+    source["steps"]["twitter"] = {
+        "time": time.time(),
+        "status": "Twitter successfully scanned at "
+        + time.strftime("%Y/%m/%d %H:%M:%S", time.gmtime(time.time())),
+        "running": False,
+        "good": True,
+    }
+    KibbleBit.updateSource(source)

--- a/kibble/scanners/utils/__init__.py
+++ b/kibble/scanners/utils/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/kibble/scanners/utils/git.py
+++ b/kibble/scanners/utils/git.py
@@ -1,0 +1,93 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+""" This is the Kibble git utility plugin """
+
+import os
+import sys
+import subprocess
+import re
+
+
+def defaultBranch(source, datapath, KibbleBit=None):
+    """ Tries to figure out what the main branch of a repo is """
+    wanted_branches = ["master", "trunk"]
+    branch = ""
+    # If we have an override of branches we like, use 'em
+    if KibbleBit and KibbleBit.config.get("git"):
+        wanted_branches = KibbleBit.config["git"].get(
+            "wanted_branches", wanted_branches
+        )
+    foundBranch = False
+
+    # For each wanted branch, in order, look for it in our clone,
+    # and return the name if found.
+    for B in wanted_branches:
+        try:
+            branch = (
+                subprocess.check_output(
+                    "cd %s && git rev-parse --abbrev-ref %s" % (datapath, B),
+                    shell=True,
+                    stderr=subprocess.DEVNULL,
+                )
+                .decode("ascii", "replace")
+                .strip()
+                .strip("* ")
+            )
+            return branch
+        except:
+            pass
+    # If we couldn't find it locally, looking at all (local+remote)
+    try:
+        inp = (
+            subprocess.check_output(
+                "cd %s && git branch -a | awk -F ' +' '! /\(no branch\)/ {print $2}'"
+                % datapath,
+                shell=True,
+                stderr=subprocess.DEVNULL,
+            )
+            .decode("ascii", "replace")
+            .split()
+        )
+        if len(inp) > 0:
+            for b in sorted(inp):
+                if b.find("detached") == -1:
+                    branch = str(b.replace("remotes/origin/", "", 1))
+                    for B in wanted_branches:
+                        if branch == B:
+                            return branch
+    except:
+        pass
+
+    # If still not found, resort to whatever branch comes first in the remote listing...
+    inp = (
+        subprocess.check_output(
+            "cd %s && git ls-remote --heads %s" % (datapath, source["sourceURL"]),
+            shell=True,
+            stderr=subprocess.DEVNULL,
+        )
+        .decode("ascii", "replace")
+        .split()
+    )
+    if len(inp) > 0:
+        for remote in inp:
+            m = re.match(r"[a-f0-9]+\s+refs/heads/(?:remotes/)?(.+)", remote)
+            if m:
+                branch = m.group(1)
+                return branch
+    # Give up
+    return ""

--- a/kibble/scanners/utils/github.py
+++ b/kibble/scanners/utils/github.py
@@ -1,0 +1,97 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+""" GitHub utility library """
+import re
+import requests
+import time
+
+repo_pattern = re.compile(".*[:/]([^/]+)/([^/]+).git")
+issues_api = "https://api.github.com/repos/%s/%s/issues"
+traffic_api = "https://api.github.com/repos/%s/%s/traffic"
+popular_api = "https://api.github.com/repos/%s/%s/popular"
+rate_limit_api = "https://api.github.com/rate_limit"
+
+
+def get_limited(url, params=None, auth=None):
+    """ Get a GitHub API response, keeping in mind that we may
+        be rate-limited by the abuse system """
+    number_of_retries = 0
+    resp = requests.get(url, params=params, auth=auth)
+    while resp.status_code == 403 and number_of_retries < 20:
+        js = resp.json()
+        # If abuse-detection kicks in, sleep it off
+        if "You have triggered an abuse" in js["message"]:
+            time.sleep(5)
+            number_of_retries += 1
+            resp = requests.get(url, params=params, auth=auth)
+        else:
+            break
+    resp.raise_for_status()
+    return resp.json()
+
+
+def get_tokens_left(auth=None):
+    """ Gets number of GitHub tokens left this hour... """
+    js = get_limited(rate_limit_api, auth=auth)
+    tokens_left = js["rate"]["remaining"]
+    return tokens_left
+
+
+def issues(source, params={}, auth=None):
+    local_params = {"per_page": 100, "page": 1}
+    local_params.update(params)
+
+    repo_user = repo_pattern.findall(source["sourceURL"])[0]
+    return get_limited(issues_api % repo_user, params=local_params, auth=auth)
+
+
+def views(source, auth=None):
+    repo_user = repo_pattern.findall(source["sourceURL"])[0]
+    return get_limited("%s/views" % (traffic_api % repo_user), auth=auth)
+
+
+def clones(source, auth=None):
+    repo_user = repo_pattern.findall(source["sourceURL"])[0]
+    return get_limited("%s/clones" % (traffic_api % repo_user), auth=auth)
+
+
+def referrers(source, auth=None):
+    repo_user = repo_pattern.findall(source["sourceURL"])[0]
+    return get_limited("%s/referrers" % (popular_api % repo_user), auth=auth)
+
+
+def user(user_url, auth=None):
+    return get_limited(user_url, auth=auth)
+
+
+def get_all(source, f, params={}, auth=None):
+    acc = []
+    page = params.get("page", 1)
+
+    while True:
+        time.sleep(1.5)
+        items = f(source, params=params, auth=auth)
+        if not items:
+            break
+
+        acc.extend(items)
+
+        page = page + 1
+        params.update({"page": page})
+
+    return acc

--- a/kibble/scanners/utils/jsonapi.py
+++ b/kibble/scanners/utils/jsonapi.py
@@ -1,0 +1,108 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""
+This is a Kibble JSON API plugin.
+"""
+import requests
+import time
+import base64
+
+CONNECT_TIMEOUT = 2  # Max timeout for the connect part of a request.
+
+
+# Should be set low as it may otherwise freeze the scanner.
+def get(url, cookie=None, auth=None, token=None, retries=5, timeout=30):
+    headers = {
+        "Content-type": "application/json",
+        "Accept": "application/json",
+        "User-Agent": "Apache Kibble",
+    }
+    if auth:
+        xcreds = auth.encode(encoding="ascii", errors="replace")
+        bauth = (
+            base64.encodebytes(xcreds)
+            .decode("ascii", errors="replace")
+            .replace("\n", "")
+        )
+        headers["Authorization"] = "Basic %s" % bauth
+    if token:
+        headers["Authorization"] = "token %s" % token
+    if cookie:
+        headers["Cookie"] = cookie
+    rv = requests.get(url, headers=headers, timeout=(CONNECT_TIMEOUT, timeout))
+    # Some services may be rate limited. We'll try sleeping it off in 60 second
+    # intervals for a max of five minutes, then give up.
+    if rv.status_code == 429:
+        if retries > 0:
+            time.sleep(60)
+            retries -= 1
+            return get(
+                url,
+                cookie=cookie,
+                auth=auth,
+                token=token,
+                retries=retries,
+                timeout=timeout,
+            )
+    if rv.status_code < 400:
+        return rv.json()
+    raise requests.exceptions.ConnectionError(
+        "Could not fetch JSON, server responded with status code %u" % rv.status_code,
+        response=rv,
+    )
+
+
+def gettxt(url, cookie=None, auth=None):
+    """ Same as above, but returns as text blob """
+    headers = {"Content-type": "application/json", "Accept": "*/*"}
+    if auth:
+        xcreds = auth.encode(encoding="ascii", errors="replace")
+        bauth = (
+            base64.encodebytes(xcreds)
+            .decode("ascii", errors="replace")
+            .replace("\n", "")
+        )
+        headers["Authorization"] = "Basic %s" % bauth
+    if cookie:
+        headers["Cookie"] = cookie
+    rv = requests.get(url, headers=headers)
+    js = rv.text
+    if rv.status_code != 404:
+        return js
+    return None
+
+
+def post(url, data, cookie=None, auth=None):
+    headers = {
+        "Content-type": "application/json",
+        "Accept": "*/*",
+        "User-Agent": "Apache Kibble",
+    }
+    if auth:
+        xcreds = auth.encode(encoding="ascii", errors="replace")
+        bauth = (
+            base64.encodebytes(xcreds)
+            .decode("ascii", errors="replace")
+            .replace("\n", "")
+        )
+        headers["Authorization"] = "Basic %s" % bauth
+    if cookie:
+        headers["Cookie"] = cookie
+    rv = requests.post(url, headers=headers, json=data)
+    js = rv.json()
+    return js

--- a/kibble/scanners/utils/kpe.py
+++ b/kibble/scanners/utils/kpe.py
@@ -1,0 +1,169 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""
+This is an experimental key phrase extraction plugin for using
+Azure/picoAPI for analyzing the key elements of an email on a list. This
+requires an account with a text analysis service provider, and a
+corresponding API section in config.yaml, as such:
+
+# picoAPI example:
+picoapi:
+    key: abcdef1234567890
+
+# Azure example:
+azure:
+    apikey: abcdef1234567890
+    location: westeurope
+
+Currently only pony mail is supported. more to come.
+"""
+
+import re
+import requests
+import json
+
+
+def trimBody(body):
+    """ Quick function for trimming away the fat from emails """
+    # Cut away "On $date, jane doe wrote: " kind of texts
+    body = re.sub(
+        r"(((?:\r?\n|^)((on .+ wrote:[\r\n]+)|(sent from my .+)|(>+[ \t]*[^\r\n]*\r?\n[^\n]*\n*)+)+)+)",
+        "",
+        body,
+        flags=re.I | re.M,
+    )
+
+    # Crop out quotes
+    lines = body.split("\n")
+    body = "\n".join([x for x in lines if not x.startswith(">")])
+
+    # Remove hyperlinks
+    body = re.sub(r"[a-z]+://\S+", "", body)
+
+    # Remove email addresses
+    body = re.sub(r"(<[^>]+>\s*\S+@\S+)", "", body)
+    body = re.sub(r"(\S+@\S+)", "", body)
+    return body
+
+
+def azureKPE(KibbleBit, bodies):
+    """ KPE using Azure Text Analysis API """
+    if "azure" in KibbleBit.config:
+        headers = {
+            "Content-Type": "application/json",
+            "Ocp-Apim-Subscription-Key": KibbleBit.config["azure"]["apikey"],
+        }
+
+        js = {"documents": []}
+
+        # For each body...
+        a = 0
+        KPEs = []
+        for body in bodies:
+            # Crop out quotes
+            lines = body.split("\n")
+            body = trimBody(body)
+            doc = {"language": "en", "id": str(a), "text": body}
+            js["documents"].append(doc)
+            KPEs.append({})  # placeholder for each doc, to be replaced
+            a += 1
+        try:
+            rv = requests.post(
+                "https://%s.api.cognitive.microsoft.com/text/analytics/v2.0/keyPhrases"
+                % KibbleBit.config["azure"]["location"],
+                headers=headers,
+                data=json.dumps(js),
+            )
+            jsout = rv.json()
+        except:
+            jsout = {}  # borked sentiment analysis?
+
+        if "documents" in jsout and len(jsout["documents"]) > 0:
+            for doc in jsout["documents"]:
+                KPEs[int(doc["id"])] = doc["keyPhrases"][
+                    :5
+                ]  # Replace KPEs[X] with the actual phrases, 5 first ones.
+
+        else:
+            KibbleBit.pprint("Failed to analyze email body.")
+            print(jsout)
+            # Depending on price tier, Azure will return a 429 if you go too fast.
+            # If we see a statusCode return, let's just stop for now.
+            # Later scans can pick up the slack.
+            if "statusCode" in jsout:
+                KibbleBit.pprint("Possible rate limiting in place, stopping for now.")
+                return False
+        return KPEs
+
+
+def picoKPE(KibbleBit, bodies):
+    """ KPE using picoAPI Text Analysis """
+    if "picoapi" in KibbleBit.config:
+        headers = {
+            "Content-Type": "application/json",
+            "PicoAPI-Key": KibbleBit.config["picoapi"]["key"],
+        }
+
+        js = {"texts": []}
+
+        # For each body...
+        a = 0
+        KPEs = []
+        for body in bodies:
+            body = trimBody(body)
+
+            doc = {"id": str(a), "body": body}
+            js["texts"].append(doc)
+            KPEs.append({})  # placeholder for each doc, to be replaced
+            a += 1
+        try:
+            rv = requests.post(
+                "https://v1.picoapi.com/api/text/keyphrase",
+                headers=headers,
+                data=json.dumps(js),
+            )
+            jsout = rv.json()
+        except:
+            jsout = {}  # borked sentiment analysis?
+
+        if "results" in jsout and len(jsout["results"]) > 0:
+            for doc in jsout["results"]:
+                phrases = []
+                # This is a bit different than Azure, in that it has a weighting score
+                # So we need to just extract key phrases above a certain level.
+                # Grab up o 5 key phrases per text
+                MINIMUM_WEIGHT = 0.02
+                for element in doc["keyphrases"]:
+                    if element["score"] > MINIMUM_WEIGHT:
+                        phrases.append(element["phrase"])
+                    if len(phrases) == 5:
+                        break
+                KPEs[
+                    int(doc["id"])
+                ] = phrases  # Replace KPEs[X] with the actual phrases
+
+        else:
+            KibbleBit.pprint("Failed to analyze email body.")
+            print(jsout)
+            # 403 returned on invalid key, 429 on rate exceeded.
+            # If we see a code return, let's just stop for now.
+            # Later scans can pick up the slack.
+            if "code" in jsout:
+                KibbleBit.pprint("Possible rate limiting in place, stopping for now.")
+                return False
+        return KPEs

--- a/kibble/scanners/utils/sloc.py
+++ b/kibble/scanners/utils/sloc.py
@@ -1,0 +1,78 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+""" This is the SLoC counter utility for Kibble """
+
+import subprocess
+import re
+import multiprocessing
+
+
+def count(path):
+    """ Count lines of Code """
+    # We determine how many cores there are, and adjust the
+    # process count based on that. Max 4 procs.
+    my_core_count = min((4, int(multiprocessing.cpu_count())))
+    inp = subprocess.check_output(
+        "cloc --quiet --progress-rate=0 --processes=%u %s" % (my_core_count, path),
+        shell=True,
+    ).decode("ascii", "replace")
+    m = re.search(
+        r".*Language\s+files\s+blank\s+comment\s+code[\s\S]+?-+([\s\S]+?)-+[\s\S]+?SUM:\s+(\d+)\s+(\d+)\s+(\d+)\s+(\d+)",
+        inp,
+        flags=re.MULTILINE | re.UNICODE,
+    )
+    languages = {}
+    ccount = 0
+    years = 0
+    cost = 0
+    codecount = ""
+    comment = ""
+    blank = ""
+    if m:
+        lingos = m.group(1)
+        fcount = m.group(2)
+        blank = m.group(3)
+        comment = m.group(4)
+        codecount = m.group(5)
+        for lm in re.finditer(
+            r"([A-Za-z +-/0-9]+)\s+\d+\s+(\d+)\s+(\d+)\s+(\d+)", lingos
+        ):
+            lang = lm.group(1).replace(" Header", "").lower()
+            lang = re.sub(r"\s\s+", "", lang)
+            lang = re.sub(r"^[Cc]\\?/", "", lang)
+            lang = lang.replace(".", "_")
+            if len(lang) > 0:
+                C = 0
+                D = 0
+                E = 0
+                if lang in languages:
+                    C = languages[lang]["code"]
+                    D = languages[lang]["comment"]
+                    E = languages[lang]["blank"]
+                languages[lang] = {
+                    "code": int(lm.group(4)) + C,
+                    "comment": int(lm.group(3)) + D,
+                    "blank": int(lm.group(2)) + E,
+                }
+        ccount = int(codecount.replace(",", "")) + int(comment.replace(",", ""))
+        codecount = int(codecount.replace(",,", ""))
+        blank = int(blank.replace(",,", ""))
+        comment = int(comment.replace(",,", ""))
+        years = ccount / 3300.0
+        cost = years * 72000
+    return [languages, codecount, comment, blank, years, cost]

--- a/kibble/scanners/utils/tone.py
+++ b/kibble/scanners/utils/tone.py
@@ -1,0 +1,197 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""
+This is an experimental tone analyzer plugin for using Watson/BlueMix for
+analyzing the mood of email on a list. This requires a Watson account
+and a watson section in config.yaml, as such:
+
+watson:
+    username: $user
+    password: $pass
+    api:      https://$something.watsonplatform.net/tone-analyzer/api
+
+Currently only pony mail is supported. more to come.
+"""
+
+import requests
+import json
+
+
+def watsonTone(KibbleBit, bodies):
+    """ Sentiment analysis using IBM Watson """
+    if "watson" in KibbleBit.config:
+        headers = {"Content-Type": "application/json"}
+
+        # Crop out quotes
+        for body in bodies:
+            lines = body.split("\n")
+            body = "\n".join([x for x in lines if not x.startswith(">")])
+
+            js = {"text": body}
+            try:
+                rv = requests.post(
+                    "%s/v3/tone?version=2017-09-21&sentences=false"
+                    % KibbleBit.config["watson"]["api"],
+                    headers=headers,
+                    data=json.dumps(js),
+                    auth=(
+                        KibbleBit.config["watson"]["username"],
+                        KibbleBit.config["watson"]["password"],
+                    ),
+                )
+                jsout = rv.json()
+            except:
+                jsout = {}  # borked Watson?
+            mood = {}
+            if "document_tone" in jsout:
+                for tone in jsout["document_tone"]["tones"]:
+                    mood[tone["tone_id"]] = tone["score"]
+            else:
+                KibbleBit.pprint("Failed to analyze email body.")
+            yield mood
+
+
+def azureTone(KibbleBit, bodies):
+    """ Sentiment analysis using Azure Text Analysis API """
+    if "azure" in KibbleBit.config:
+        headers = {
+            "Content-Type": "application/json",
+            "Ocp-Apim-Subscription-Key": KibbleBit.config["azure"]["apikey"],
+        }
+
+        js = {"documents": []}
+
+        # For each body...
+        a = 0
+        moods = []
+        for body in bodies:
+            # Crop out quotes
+            lines = body.split("\n")
+            body = "\n".join([x for x in lines if not x.startswith(">")])
+            doc = {"language": "en", "id": str(a), "text": body}
+            js["documents"].append(doc)
+            moods.append({})  # placeholder for each doc, to be replaced
+            a += 1
+        try:
+            rv = requests.post(
+                "https://%s.api.cognitive.microsoft.com/text/analytics/v2.0/sentiment"
+                % KibbleBit.config["azure"]["location"],
+                headers=headers,
+                data=json.dumps(js),
+            )
+            jsout = rv.json()
+        except:
+            jsout = {}  # borked sentiment analysis?
+
+        if "documents" in jsout and len(jsout["documents"]) > 0:
+            for doc in jsout["documents"]:
+                mood = {}
+                # This is more parred than Watson, so we'll split it into three groups: positive, neutral and negative.
+                # Divide into four segments, 0->40%, 25->75% and 60->100%.
+                # 0-40 promotes negative, 60-100 promotes positive, and 25-75% promotes neutral.
+                # As we don't want to over-represent negative/positive where the results are
+                # muddy, the neutral zone is larger than the positive/negative zones by 10%.
+                val = doc["score"]
+                mood["negative"] = max(
+                    0, ((0.4 - val) * 2.5)
+                )  # For 40% and below, use 2½ distance
+                mood["positive"] = max(
+                    0, ((val - 0.6) * 2.5)
+                )  # For 60% and above, use 2½ distance
+                mood["neutral"] = max(
+                    0, 1 - (abs(val - 0.5) * 2)
+                )  # Between 25% and 75% use double the distance to middle.
+                moods[int(doc["id"])] = mood  # Replace moods[X] with the actual mood
+
+        else:
+            KibbleBit.pprint("Failed to analyze email body.")
+            print(jsout)
+            # Depending on price tier, Azure will return a 429 if you go too fast.
+            # If we see a statusCode return, let's just stop for now.
+            # Later scans can pick up the slack.
+            if "statusCode" in jsout:
+                KibbleBit.pprint("Possible rate limiting in place, stopping for now.")
+                return False
+        return moods
+
+
+def picoTone(KibbleBit, bodies):
+    """ Sentiment analysis using picoAPI Text Analysis """
+    if "picoapi" in KibbleBit.config:
+        headers = {
+            "Content-Type": "application/json",
+            "PicoAPI-Key": KibbleBit.config["picoapi"]["key"],
+        }
+
+        js = {"texts": []}
+
+        # For each body...
+        a = 0
+        moods = []
+        for body in bodies:
+            # Crop out quotes
+            lines = body.split("\n")
+            body = "\n".join([x for x in lines if not x.startswith(">")])
+            doc = {"id": str(a), "body": body}
+            js["texts"].append(doc)
+            moods.append({})  # placeholder for each doc, to be replaced
+            a += 1
+        try:
+            rv = requests.post(
+                "https://v1.picoapi.com/api/text/sentiment",
+                headers=headers,
+                data=json.dumps(js),
+            )
+            jsout = rv.json()
+        except:
+            jsout = {}  # borked sentiment analysis?
+
+        if "results" in jsout and len(jsout["results"]) > 0:
+            for doc in jsout["results"]:
+                mood = {}
+
+                # Sentiment is the overall score, and we use that for the neutrality of a text
+                val = (1 + doc["sentiment"]) / 2
+
+                mood["negative"] = doc[
+                    "negativity"
+                ]  # Use the direct Bayesian score from picoAPI
+                mood["positive"] = doc[
+                    "positivity"
+                ]  # Use the direct Bayesian score from picoAPI
+                mood["neutral"] = doc[
+                    "neutrality"
+                ]  # Calc neutrality to favor a middle sentiment score, ignore high/low
+
+                # Additional (optional) emotion weighting
+                if "emotions" in doc:
+                    for k, v in doc["emotions"].items():
+                        mood[k] = v / 100  # Value is betwen 0 and 100.
+
+                moods[int(doc["id"])] = mood  # Replace moods[X] with the actual mood
+
+        else:
+            KibbleBit.pprint("Failed to analyze email body.")
+            print(jsout)
+            # 403 returned on invalid key, 429 on rate exceeded.
+            # If we see a code return, let's just stop for now.
+            # Later scans can pick up the slack.
+            if "code" in jsout:
+                KibbleBit.pprint("Possible rate limiting in place, stopping for now.")
+                return False
+        return moods

--- a/kibble/scanners/utils/urlmisc.py
+++ b/kibble/scanners/utils/urlmisc.py
@@ -1,0 +1,79 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""
+This is a Kibble miscellaneous URL functions plugin.
+"""
+import base64
+import urllib.request
+import gzip
+import tempfile
+import io
+import subprocess
+
+
+def unzip(url, creds=None, cookie=None):
+    """ Attempts to download an unzip an archive. Returns the
+    temporary file path of the unzipped contents """
+    headers = {}
+    if creds:
+        auth = str(base64.encodestring(bytes(creds)).replace("\n", ""))
+        headers = {
+            "Content-type": "application/json",
+            "Accept": "*/*",
+            "Authorization": "Basic %s" % auth,
+        }
+    if cookie:
+        headers = {
+            "Content-type": "application/json",
+            "Accept": "*/*",
+            "Cookie": cookie,
+        }
+    request = urllib.request.Request(url, headers=headers)
+    # Try fechthing via python, fall back to wget (redhat == broken!)
+    decompressedFile = None
+    try:
+        result = urllib.request.urlopen(request)
+        compressedFile = io.BytesIO()
+        compressedFile.write(result.read())
+        compressedFile.seek(0)
+        decompressedFile = gzip.GzipFile(fileobj=compressedFile, mode="rb")
+    except urllib.error.HTTPError as err:
+        # We're not interested in 404s, only transport errors
+        if err.code != 404 and err.code != 401:
+            tmpfile = tempfile.NamedTemporaryFile(mode="w+b", buffering=1, delete=False)
+            subprocess.check_call(("/usr/bin/wget", "-O", tmpfile.name, url))
+
+            try:
+                te
+                compressedFile = open("/tmp/kibbletmp.gz", "rb")
+                if compressedFile.read(2) == "\x1f\x8b":
+                    compressedFile.seek(0)
+                    decompressedFile = gzip.GzipFile(fileobj=compressedFile, mode="rb")
+                else:
+                    compressedFile.close()
+                    return tmpfile.name
+            except:
+                # Probably not a gzipped file!
+                decompressedFile = open(tmpfile.name, "rb")
+    if decompressedFile:
+        tmpfile = tempfile.NamedTemporaryFile(mode="w+b", buffering=1, delete=False)
+        tmpfile.write(decompressedFile.read())
+        tmpfile.flush()
+        tmpfile.close()
+        return tmpfile.name
+    return None

--- a/setup.py
+++ b/setup.py
@@ -35,8 +35,11 @@ INSTALL_REQUIREMENTS = [
     "certifi==2020.6.20",
     "elasticsearch==7.9.1",
     "gunicorn==20.0.4",
+    "psutil==5.7.3",
     "python-dateutil==2.8.1",
+    "python-twitter==3.5",
     "PyYAML==5.3.1",
+    "requests==2.24.0",
     "tenacity==6.2.0",
 ]
 


### PR DESCRIPTION
This PR moves Apache Kibble scanners from 
https://github.com/apache/kibble-scanners to https://github.com/apache/kibble 
as discussed here:
https://lists.apache.org/thread.html/r3f373be93397fc55ad6aff11030d2f3eb93f0f34782ff58fba9325b1%40%3Cdev.kibble.apache.org%3E

I reviewed all files and fixed licenses headers, removed unused imports and adjusted imports. It seems to look good:
```
➜ python kibble/scanners/kibble-scanner.py
[core]: Loaded plugins/scanners/git-sync v/0.1.2 (Sync plugin for Git repositories)
[core]: Loaded plugins/scanners/git-census v/0.1.0 (Census Scanner for Git)
[core]: Loaded plugins/scanners/git-sloc v/0.1.0 (SloC Counter for Git)
[core]: Loaded plugins/scanners/git-evolution v/0.1.0 (Git Evolution Scanner)
[core]: Loaded plugins/scanners/jira v/0.1.0 (Scanner for Atlassian JIRA)
[core]: Loaded plugins/scanners/ponymail v/0.1.0 (Scanner plugin for Apache Pony Mail)
[core]: Loaded plugins/scanners/ponymail-tone v/0.1.0 (Tone/Mood Scanner plugin for Apache Pony Mail)
[core]: Loaded plugins/scanners/ponymail-kpe v/0.1.0 (Key Phrase Extraction plugin for Apache Pony Mail)
[core]: Loaded plugins/scanners/pipermail v/0.1.0 (Scanner for GNU Mailman Pipermail)
[core]: Loaded plugins/scanners/github-issues v/0.1.0 (Scanner for GitHub Issues)
[core]: Loaded plugins/scanners/bugzilla v/0.1.0 (Scanner for BugZilla)
[core]: Loaded plugins/scanners/gerrit v/0.1.1 (Scanner for Gerrit Code Review)
[core]: Loaded plugins/scanners/jenkins v/0.1.0 (Scanner for Jenkins CI)
[core]: Loaded plugins/scanners/buildbot v/0.1.0 (Scanner for Buildbot)
[core]: Loaded plugins/scanners/travis v/0.1.0 (Scanner for Travis CI)
[core]: Loaded plugins/scanners/discourse v/0.1.0 (Scanner for Discourse Forums)
'Kibble Scanner v/0.1.0 starting'
kibble/scanners/kibble-scanner.py:141: YAMLLoadWarning: calling yaml.load() without Loader=... is deprecated, as the default Loader is unsafe. Please read https://msg.pyyaml.org/load for full details.
  config = yaml.load(open(CONFIG_FILE))
('Loaded YAML config from '
 '/Users/turbaszek/code/kibble/kibble/scanners/config.yaml')
'Using direct ElasticSearch broker model'
[core]: Connecting to ElasticSearch database at localhost:9200...
[core]: Connected!
[core]: This is a type-less DB, expanding database names instead.
[core]: We're using ES >= 7.x, NO DOC_TYPE!
'All done scanning for now, found 0 organisations and 0 sources to process.'
```

However, doing this review I found few errors in implementation (undefined variables, missing imports etc) and I'm wondering, wouldn't it be better to add the scanners one by one to improve them in this process?

Probably we should do this once we have #77