### PR TITLE
Update pre-commits hook from 2.3 to 3.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,7 +24,7 @@ minimum_pre_commit_version: "1.20.0"
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.3.0
+    rev: v3.3.0
     hooks:
       - id: check-yaml
       - id: end-of-file-fixer


### PR DESCRIPTION
3.3 is out for https://github.com/pre-commit/pre-commit-hooks

cc @turbaszek 