### PR TITLE
Fix broken Kibble

### DIFF
--- a/docker-compose-dev.yaml
+++ b/docker-compose-dev.yaml
@@ -1,5 +1,9 @@
 version: '3'
 
+networks:
+  kibble:
+    driver: bridge
+
 services:
   # Helper service to setup the Apache Kibble es node
   setup:
@@ -12,6 +16,8 @@ services:
       - .:/kibble/
     depends_on:
       - elasticsearch
+    networks:
+      - kibble
 
   # Apache Kibble API server
   kibble:
@@ -25,6 +31,8 @@ services:
       - .:/kibble/
     depends_on:
       - elasticsearch
+    networks:
+      - kibble
 
   # Apache Kibble web ui server
   ui:
@@ -35,6 +43,8 @@ services:
     ports:
       - 8000:8000
     depends_on:
+      - kibble
+    networks:
       - kibble
 
   # Elasticsearch node required as a database for Apache Kibble
@@ -51,6 +61,8 @@ services:
       ES_JAVA_OPTS: -Xms256m -Xmx256m
     volumes:
       - "kibble-es-data:/usr/share/elasticsearch/data"
+    networks:
+      - kibble
 
   # Kibana to view and manage Elasticsearch
   kibana:
@@ -59,6 +71,11 @@ services:
       - 5601:5601
     depends_on:
       - elasticsearch
+    environment:
+      ELASTICSEARCH_URL: http://elasticsearch:9200
+      ELASTICSEARCH_HOSTS: http://elasticsearch:9200
+    networks:
+      - kibble
 
 volumes:
   # named volumes can be managed easier using docker-compose

--- a/kibble/api/handler.py
+++ b/kibble/api/handler.py
@@ -27,12 +27,11 @@ import re
 import sys
 import traceback
 
-import yaml
-
 from kibble.api.plugins import openapi
 from kibble.api.plugins.database import KibbleDatabase
 from kibble.api.plugins.session import KibbleSession
-from kibble.settings import KIBBLE_YAML, YAML_DIRECTORY
+from kibble.configuration import conf
+from kibble.settings import YAML_DIRECTORY
 
 # Compile valid API URLs from the pages library
 # Allow backwards compatibility by also accepting .lua URLs
@@ -44,10 +43,6 @@ if __name__ != "__main__":
     for page, handler in handlers.items():
         urls.append((r"^(/api/%s)(/.+)?$" % page, handler.run))
 
-
-# Load Kibble master configuration
-with open(KIBBLE_YAML, "r") as f:
-    config = yaml.safe_load(f)
 
 # Instantiate database connections
 DB = None
@@ -156,13 +151,13 @@ def application(environ, start_response):
     Checks against the pages library, and if submod found, runs
     it and returns the output.
     """
-    db = KibbleDatabase(config)
+    db = KibbleDatabase(conf)
     path = environ.get("PATH_INFO", "")
     for regex, function in urls:
         m = re.match(regex, path)
         if m:
             callback = KibbleAPIWrapper(path, function)
-            session = KibbleSession(db, environ, config)
+            session = KibbleSession(db, environ, conf)
             a = 0
             for bucket in callback(environ, start_response, session):
                 if a == 0:

--- a/kibble/api/plugins/database.py
+++ b/kibble/api/plugins/database.py
@@ -22,6 +22,8 @@ It stores the elasticsearch handler and config options.
 
 import elasticsearch
 
+from kibble.configuration import KibbleConfigParser
+
 
 class KibbleESWrapper(object):
     """
@@ -119,24 +121,13 @@ class KibbleESWrapperSeven(object):
 
 
 class KibbleDatabase(object):
-    def __init__(self, config):
+    def __init__(self, config: KibbleConfigParser):
         self.config = config
-        self.dbname = config["elasticsearch"]["dbname"]
+        self.dbname = config.get("elasticsearch", "dbname")
         self.ES = elasticsearch.Elasticsearch(
-            [
-                {
-                    "host": config["elasticsearch"]["host"],
-                    "port": int(config["elasticsearch"]["port"]),
-                    "use_ssl": config["elasticsearch"]["ssl"],
-                    "verify_certs": False,
-                    "url_prefix": config["elasticsearch"]["uri"]
-                    if "uri" in config["elasticsearch"]
-                    else "",
-                    "http_auth": config["elasticsearch"]["auth"]
-                    if "auth" in config["elasticsearch"]
-                    else None,
-                }
-            ],
+            [config.get("elasticsearch", "conn_uri")],
+            use_ssl=config.getboolean("elasticsearch", "ssl"),
+            verify_certs=False,
             max_retries=5,
             retry_on_timeout=True,
         )


### PR DESCRIPTION
Before this commit I got this error when running Kibble locally:

```
kibble_1         | [2020-12-12 19:42:01 +0000] [7] [ERROR] Exception in worker process
kibble_1         | Traceback (most recent call last):
kibble_1         |   File "/usr/local/lib/python3.8/site-packages/gunicorn/arbiter.py", line 583, in spawn_worker
kibble_1         |     worker.init_process()
kibble_1         |   File "/usr/local/lib/python3.8/site-packages/gunicorn/workers/base.py", line 119, in init_process
kibble_1         |     self.load_wsgi()
kibble_1         |   File "/usr/local/lib/python3.8/site-packages/gunicorn/workers/base.py", line 144, in load_wsgi
kibble_1         |     self.wsgi = self.app.wsgi()
kibble_1         |   File "/usr/local/lib/python3.8/site-packages/gunicorn/app/base.py", line 67, in wsgi
kibble_1         |     self.callable = self.load()
kibble_1         |   File "/usr/local/lib/python3.8/site-packages/gunicorn/app/wsgiapp.py", line 49, in load
kibble_1         |     return self.load_wsgiapp()
kibble_1         |   File "/usr/local/lib/python3.8/site-packages/gunicorn/app/wsgiapp.py", line 39, in load_wsgiapp
kibble_1         |     return util.import_app(self.app_uri)
kibble_1         |   File "/usr/local/lib/python3.8/site-packages/gunicorn/util.py", line 358, in import_app
kibble_1         |     mod = importlib.import_module(module)
kibble_1         |   File "/usr/local/lib/python3.8/importlib/__init__.py", line 127, in import_module
kibble_1         |     return _bootstrap._gcd_import(name[level:], package, level)
kibble_1         |   File "<frozen importlib._bootstrap>", line 1014, in _gcd_import
kibble_1         |   File "<frozen importlib._bootstrap>", line 991, in _find_and_load
kibble_1         |   File "<frozen importlib._bootstrap>", line 975, in _find_and_load_unlocked
kibble_1         |   File "<frozen importlib._bootstrap>", line 671, in _load_unlocked
kibble_1         |   File "<frozen importlib._bootstrap_external>", line 783, in exec_module
kibble_1         |   File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
kibble_1         |   File "/kibble/kibble/api/handler.py", line 49, in <module>
kibble_1         |     with open(KIBBLE_YAML, "r") as f:
kibble_1         | FileNotFoundError: [Errno 2] No such file or directory: '/kibble/kibble/api/yaml/kibble.yaml'
kibble_1         | [2020-12-12 19:42:01 +0000] [7] [INFO] Worker exiting (pid: 7)
```

This was because https://github.com/apache/kibble/pull/83 replaced kibble.yaml with kibble.ini

This PR reads the config from `kibble.ini`.

This also adds a network to docker-compose file without which I was getting host not found error.