### PR TITLE
Use python:3.8-slim image for Dockerfile

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -15,11 +15,11 @@
 # specific language governing permissions and limitations
 # under the License.
 
-FROM python:3.8
+FROM python:3.8-slim
 
 USER root
 RUN apt-get update
-RUN apt-get install -y gcc unzip
+RUN apt-get install -y gcc git unzip
 
 COPY . /kibble/
 


### PR DESCRIPTION
`python:3.8` -- 331.8 MB
`python:3.8-slim` -- 41.67 MB

https://hub.docker.com/_/python?tab=tags&page=1&ordering=last_updated&name=3.8

