### PR TITLE
Fix error when running Kibble Scanner

### DIFF
--- a/kibble/scanners/brokers/kibbleES.py
+++ b/kibble/scanners/brokers/kibbleES.py
@@ -335,18 +335,21 @@ class Broker:
         apidoc = es.get(index=es_config["database"], doc_type="api", id="current")[
             "_source"
         ]
+        apidoc_db_version = int(apidoc["dbversion"])
         # We currently accept and know how to use DB versions 1 and 2.
-        if apidoc["dbversion"] not in ACCEPTED_DB_VERSIONS:
-            if apidoc["dbversion"] > KIBBLE_DB_VERSION:
+        if apidoc_db_version not in ACCEPTED_DB_VERSIONS:
+            if apidoc_db_version > KIBBLE_DB_VERSION:
                 sys.stderr.write(
-                    "The database '%s' uses a newer structure format (version %u) than the scanners (version %u). Please upgrade your scanners.\n"
-                    % (es_config["database"], apidoc["dbversion"], KIBBLE_DB_VERSION)
+                    "The database '%s' uses a newer structure format (version %u) than the scanners "
+                    "(version %u). Please upgrade your scanners.\n"
+                    % (es_config["database"], apidoc_db_version, KIBBLE_DB_VERSION)
                 )
                 sys.exit(-1)
-            if apidoc["dbversion"] < KIBBLE_DB_VERSION:
+            if apidoc_db_version < KIBBLE_DB_VERSION:
                 sys.stderr.write(
-                    "The database '%s' uses an older structure format (version %u) than the scanners (version %u). Please upgrade your main Kibble server.\n"
-                    % (es_config["database"], apidoc["dbversion"], KIBBLE_DB_VERSION)
+                    "The database '%s' uses an older structure format (version %u) than the scanners "
+                    "(version %u). Please upgrade your main Kibble server.\n"
+                    % (es_config["database"], apidoc_db_version, KIBBLE_DB_VERSION)
                 )
                 sys.exit(-1)
 


### PR DESCRIPTION
Error before this commit when running kibble-scanner:

```
'Using direct ElasticSearch broker model'
[core]: Connecting to ElasticSearch database at elasticsearch:9200...
[core]: Connected!
[core]: This is a type-less DB, expanding database names instead.
[core]: We're using ES >= 7.x, NO DOC_TYPE!
Traceback (most recent call last):
  File "kibble-scanner.py", line 197, in <module>
    main()
  File "kibble-scanner.py", line 145, in main
    broker = kibbleES.Broker(config)
  File "/kibble/kibble/scanners/brokers/kibbleES.py", line 340, in __init__
    if apidoc["dbversion"] > KIBBLE_DB_VERSION:
TypeError: '>' not supported between instances of 'str' and 'int'
```

This PR fixes it

cc @turbaszek @michalslowikowski00 @Humbedooh

