### PR TITLE
Install cloc in Dockerfile to fix git scanner

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -19,7 +19,7 @@ FROM python:3.8
 
 USER root
 RUN apt-get update
-RUN apt-get install -y gcc unzip
+RUN apt-get install -y gcc unzip cloc
 
 COPY . /kibble/
 


### PR DESCRIPTION
Install cloc (https://github.com/AlDanial/cloc).

`cloc` is a Prerequisite as mentioned in https://apache-kibble.readthedocs.io/en/latest/setup.html#installing-the-server

Without it the count in the git scanner fails with following:

```
[thread#1:plugins/scanners/git-sloc]: Running SLoC count for https://github.com/kaxil/boring-cyborg.git
/bin/sh: 1: cloc: not found
Exception in thread Thread-1:
Traceback (most recent call last):
  File "/usr/local/lib/python3.8/threading.py", line 932, in _bootstrap_inner
    self.run()
  File "kibble-scanner.py", line 126, in run
    scanner.scan(self.bit, obj)
  File "/kibble/kibble/scanners/scanners/git-sloc.py", line 68, in scan
    languages, codecount, comment, blank, years, cost = sloc.count(gpath)
  File "/kibble/kibble/scanners/utils/sloc.py", line 30, in count
    inp = subprocess.check_output(
  File "/usr/local/lib/python3.8/subprocess.py", line 411, in check_output
    return run(*popenargs, stdout=PIPE, timeout=timeout, check=True,
  File "/usr/local/lib/python3.8/subprocess.py", line 512, in run
    raise CalledProcessError(retcode, process.args,
subprocess.CalledProcessError: Command 'cloc --quiet --progress-rate=0 --processes=4 /tmp/kaxil/git/2a219855377dc934c4fe168fe21b8fdf2fe3d5733fc86e93ea4a3cff' returned non-zero exit status 127.
'All done scanning for now, found 1 organisations and 1 sources to process.'
```

cc @turbaszek @michalslowikowski00 @Humbedooh

