### PR TITLE
Fix unresolved reference error in kibble/api/plugins/database.py

### DIFF
--- a/kibble/api/plugins/database.py
+++ b/kibble/api/plugins/database.py
@@ -138,5 +138,5 @@ class KibbleDatabase(object):
         self.ESversion = int(self.ES.info()["version"]["number"].split(".")[0])
         if self.ESversion >= 7:
             self.ES = KibbleESWrapperSeven(self.ES)
-        elif self.ESVersion >= 6:
+        elif self.ESversion >= 6:
             self.ES = KibbleESWrapper(self.ES)


### PR DESCRIPTION
There was no such variable `ESVersion` -- possibly a typo as `self.ESversion` is defined on line 147

cc @turbaszek 