### PR TITLE
Introduce a BaseScanner class

### DIFF
--- a/kibble/scanners/scanners/base_scanner.py
+++ b/kibble/scanners/scanners/base_scanner.py
@@ -1,0 +1,35 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import logging
+from abc import abstractmethod
+
+from kibble.scanners.brokers.kibbleES import KibbleBit
+
+
+class BaseScanner:
+    """
+    Base scanner class. All scanners should inherit from it.
+    """
+
+    version: str
+    title: str
+    log = logging.getLogger(__name__)
+
+    @abstractmethod
+    def scan(self, kibble_bit: KibbleBit, source: dict) -> None:
+        raise NotImplementedError


### PR DESCRIPTION
This will help us refactor and standarize all scanners.
Additionally this class create a good place to have common
method which are deuplicated in many places.